### PR TITLE
refactor(lmm): merge LOCO kinship streaming into the canonical kinship function

### DIFF
--- a/src/jamma/kinship/__init__.py
+++ b/src/jamma/kinship/__init__.py
@@ -15,6 +15,7 @@ Key functions:
 
 from jamma.io.plink import get_chromosome_partitions
 from jamma.kinship.compute import (
+    SnpStatsCache,
     compute_centered_kinship,
     compute_kinship_streaming,
     compute_loco_kinship,
@@ -29,6 +30,7 @@ from jamma.kinship.io import (
 from jamma.kinship.missing import impute_and_center, impute_center_and_standardize
 
 __all__ = [
+    "SnpStatsCache",
     "compute_centered_kinship",
     "compute_kinship_streaming",
     "compute_loco_kinship",

--- a/src/jamma/kinship/compute.py
+++ b/src/jamma/kinship/compute.py
@@ -25,6 +25,7 @@ import gc
 import time
 import warnings
 from collections.abc import Callable, Iterator
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -45,10 +46,54 @@ from jamma.io.plink import (
     get_plink_metadata,
     partitions_from_metadata,
     stream_genotype_chunks,
+    validate_genotype_values,
 )
 from jamma.jlinalg import compute_snp_stats_chunk
 from jamma.kinship.missing import impute_and_center, impute_center_and_standardize
 from jamma.utils import chr_sort_key
+
+
+@dataclass(frozen=True)
+class SnpStatsCache:
+    """Global SNP statistics from kinship streaming PASS 1.
+
+    Stores per-SNP means, missing counts, and variances for ALL SNPs in the
+    BIM file (unfiltered), computed over ALL samples (including those with
+    missing phenotypes). Per-chromosome stats are extracted by indexing
+    with chr_snp_indices: cache.col_means[chr_snp_indices].
+
+    The all-samples population matters: ``n_samples`` is the denominator for
+    miss_rate and the basis for col_means / col_vars. When filtering in the
+    association pass, use ``cache.n_samples`` — NOT n_valid — to match the
+    population the stats were computed from.
+
+    Returned by ``compute_loco_kinship_streaming(return_snp_stats=True)`` so the
+    association pass can reuse PASS-1 statistics instead of re-reading the BED
+    once per chromosome.
+    """
+
+    col_means: np.ndarray  # shape (n_snps_total,), float64
+    miss_counts: np.ndarray  # shape (n_snps_total,), intp
+    col_vars: np.ndarray  # shape (n_snps_total,), float64
+    n_samples: int  # sample count stats were computed over (ALL samples)
+
+    def __post_init__(self) -> None:
+        """Validate array shapes and freeze array contents."""
+        if not (self.col_means.shape == self.miss_counts.shape == self.col_vars.shape):
+            raise ValueError(
+                f"Array shape mismatch: col_means={self.col_means.shape}, "
+                f"miss_counts={self.miss_counts.shape}, "
+                f"col_vars={self.col_vars.shape}"
+            )
+        if self.col_means.ndim != 1:
+            raise ValueError(f"Expected 1-D arrays, got ndim={self.col_means.ndim}")
+        for arr in (self.col_means, self.miss_counts, self.col_vars):
+            arr.flags.writeable = False
+
+    @property
+    def n_snps(self) -> int:
+        """Number of SNPs in the cache (unfiltered BIM count)."""
+        return self.col_means.shape[0]
 
 
 def _ensure_float64(arr: np.ndarray) -> np.ndarray:
@@ -994,7 +1039,12 @@ def compute_loco_kinship_streaming(
     ksnps_indices: np.ndarray | None = None,
     valid_indices: np.ndarray | None = None,
     _copy_yielded_matrices: bool = True,
-) -> Iterator[tuple[str, np.ndarray]]:
+    return_snp_stats: bool = False,
+    _max_batch_chrs: int | None = None,
+) -> (
+    Iterator[tuple[str, np.ndarray]]
+    | tuple[Iterator[tuple[str, np.ndarray]], SnpStatsCache]
+):
     """Compute LOCO kinship matrices from disk-streamed genotypes.
 
     Two-pass streaming approach that accumulates both S_full and per-chromosome
@@ -1022,12 +1072,21 @@ def compute_loco_kinship_streaming(
             (n_valid, n_valid) where n_valid = len(valid_indices), eliminating
             the post-hoc np.ix_ copy. When None, K_loco has shape
             (n_samples, n_samples) (default, backward-compatible).
+        return_snp_stats: If True, also return the PASS-1 SnpStatsCache (global
+            per-SNP means/miss-counts/variances over all samples) so callers
+            (the LOCO LMM pass) can reuse it instead of re-reading the BED per
+            chromosome. Changes the return type from an iterator to
+            ``(iterator, SnpStatsCache)``.
+        _max_batch_chrs: Debug override forcing a fixed chromosomes-per-pass
+            batch size (bypasses memory-based sizing). Used by tests to exercise
+            multi-pass without mocking psutil.
 
-    Yields:
-        Tuple of (chr_name, K_loco) where chr_name is the chromosome being
-        excluded and K_loco is the LOCO kinship matrix. Shape is
-        (n_valid, n_valid) when valid_indices is provided, otherwise
-        (n_samples, n_samples).
+    Returns:
+        An iterator of (chr_name, K_loco) pairs, where chr_name is the
+        chromosome being excluded and K_loco is the LOCO kinship matrix with
+        shape (n_valid, n_valid) when valid_indices is provided, else
+        (n_samples, n_samples). When ``return_snp_stats`` is True, returns
+        ``(iterator, SnpStatsCache)`` instead.
 
     Raises:
         MemoryError: If check_memory=True and insufficient memory for even
@@ -1079,7 +1138,9 @@ def compute_loco_kinship_streaming(
             stats_iterator, total=n_chunks, desc="LOCO: SNP statistics"
         )
 
+    n_unexpected_total = 0
     for chunk, start, end in stats_iterator:
+        n_unexpected_total += validate_genotype_values(chunk)
         chunk = np.ascontiguousarray(chunk)
         compute_snp_stats_chunk(
             chunk,
@@ -1088,6 +1149,26 @@ def compute_loco_kinship_streaming(
             all_vars[start:end],
         )
         del chunk  # Free ~1.6GB per chunk at scale before next iteration
+
+    if n_unexpected_total > 0:
+        logger.warning(
+            f"LOCO kinship genotype validation: {n_unexpected_total} values outside "
+            f"expected range {{0, 1, 2, NaN}}"
+        )
+
+    # Cache global PASS-1 stats (computed over ALL samples) for the association
+    # pass when requested. Must be built BEFORE the del statements below free
+    # all_means / all_vars. n_samples is the population the stats span.
+    snp_stats_cache = (
+        SnpStatsCache(
+            col_means=all_means.copy(),
+            miss_counts=all_miss_counts.copy(),
+            col_vars=all_vars.copy(),
+            n_samples=n_samples,
+        )
+        if return_snp_stats
+        else None
+    )
 
     # Compute filters
     miss_rates = all_miss_counts / n_samples
@@ -1173,122 +1254,97 @@ def compute_loco_kinship_streaming(
             f"available {available_gb:.1f}GB"
         )
 
-    single_pass = single_pass_gb <= available_gb * 0.9
-
-    if single_pass:
-        # === SINGLE-PASS: accumulate S_full and all S_chr together ===
-        if single_pass_gb > 10:
-            logger.info(
-                f"LOCO streaming: single-pass ({single_pass_gb:.1f}GB for "
-                f"{n_chr_with_snps} chromosomes)"
-            )
-
-        S_full_np, S_chr = _stream_s_full_and_chr(
-            bed_path,
-            n_samples,
-            n_snps,
-            snp_indices,
-            chromosomes,
-            chrs_with_snps,
-            chunk_size,
-            show_progress,
-            desc="LOCO: kinship accumulation",
-            valid_indices=valid_indices,
-        )
-
-        elapsed = time.perf_counter() - start_time
-        logger.info(
-            f"LOCO streaming accumulation complete in {elapsed:.2f}s, "
-            f"computing {len(S_chr)} LOCO matrices"
-        )
-
-        K_loco_buf = np.empty_like(S_full_np)
-        yield from _yield_loco_matrices(
-            S_full_np,
-            S_chr,
-            n_chr_filtered,
-            n_filtered,
-            K_loco_buf,
-            copy_output=_copy_yielded_matrices,
-        )
-        yield from _yield_full_kinship_fallback(
-            S_full_np, chrs_without_snps, n_filtered
-        )
+    # Single-pass vs multi-pass decision and the chromosomes-per-pass batch
+    # size, decided up front so the test override (_max_batch_chrs) and the
+    # memory-based sizing share one place.
+    if _max_batch_chrs is not None:
+        batch_size = _max_batch_chrs
+        single_pass = n_chr_with_snps <= batch_size
     else:
-        # === MULTI-PASS: batch chromosomes across disk passes ===
-        # First pass holds S_full + batch S_chr + chunk buffer.
-        # Reserve 2x matrix_gb for safety margin.
-        #
-        # The consumer eigendecomposes each K_loco while the generator is
-        # suspended with remaining S_chr matrices still alive. Reserve
-        # eigendecomp workspace so the batch doesn't exhaust memory before
-        # eigendecomp can run. The reservation covers the full DSYEVR peak:
-        #   - K_loco (yielded to consumer) + Z (eigenvectors) = 2 matrices
-        #   - DSYEVR workspace = O(N) additional
-        eigendecomp_reserve_gb = _dsyevr_peak_gb(n_samples)
-        usable_gb = (
-            available_gb * 0.9
-            - 2 * matrix_gb
-            - chunk_buffer_gb
-            - eigendecomp_reserve_gb
-        )
-        batch_size = max(1, int(usable_gb / matrix_gb))
+        single_pass = single_pass_gb <= available_gb * 0.9
+        if single_pass:
+            batch_size = n_chr_with_snps  # unused in the single-pass branch
+        else:
+            # The consumer eigendecomposes each K_loco while the generator is
+            # suspended with remaining S_chr matrices still alive. Reserve
+            # eigendecomp workspace (full DSYEVR peak: K_loco + Z + O(N)) so the
+            # batch doesn't exhaust memory before eigendecomp can run.
+            eigendecomp_reserve_gb = _dsyevr_peak_gb(n_samples)
+            usable_gb = (
+                available_gb * 0.9
+                - 2 * matrix_gb
+                - chunk_buffer_gb
+                - eigendecomp_reserve_gb
+            )
+            batch_size = max(1, int(usable_gb / matrix_gb))
 
-        n_batches = (n_chr_with_snps + batch_size - 1) // batch_size
-        logger.warning(
-            f"LOCO streaming: multi-pass mode ({n_batches} passes, "
-            f"{batch_size} chromosomes/pass). Single-pass would need "
-            f"{single_pass_gb:.1f}GB, available {available_gb:.1f}GB."
-        )
+    def _generate() -> Iterator[tuple[str, np.ndarray]]:
+        if single_pass:
+            # === SINGLE-PASS: accumulate S_full and all S_chr together ===
+            if single_pass_gb > 10:
+                logger.info(
+                    f"LOCO streaming: single-pass ({single_pass_gb:.1f}GB for "
+                    f"{n_chr_with_snps} chromosomes)"
+                )
 
-        # First batch: compute S_full + first batch of S_chr
-        first_batch = chrs_with_snps[:batch_size]
-        S_full_np, S_chr = _stream_s_full_and_chr(
-            bed_path,
-            n_samples,
-            n_snps,
-            snp_indices,
-            chromosomes,
-            first_batch,
-            chunk_size,
-            show_progress,
-            desc=f"LOCO: pass 1/{n_batches} (S_full + {len(first_batch)} chr)",
-            valid_indices=valid_indices,
-        )
-
-        K_loco_buf = np.empty_like(S_full_np)
-        yield from _yield_loco_matrices(
-            S_full_np,
-            S_chr,
-            n_chr_filtered,
-            n_filtered,
-            K_loco_buf,
-            copy_output=_copy_yielded_matrices,
-        )
-        del S_chr
-        gc.collect()
-
-        # Subsequent batches: only accumulate S_chr (S_full already computed)
-        for batch_idx in range(1, n_batches):
-            batch_start = batch_idx * batch_size
-            batch_chrs = chrs_with_snps[batch_start : batch_start + batch_size]
-
-            _, S_chr = _stream_s_full_and_chr(
+            S_full_np, S_chr = _stream_s_full_and_chr(
                 bed_path,
                 n_samples,
                 n_snps,
                 snp_indices,
                 chromosomes,
-                batch_chrs,
+                chrs_with_snps,
                 chunk_size,
                 show_progress,
-                desc=(
-                    f"LOCO: pass {batch_idx + 1}/{n_batches} ({len(batch_chrs)} chr)"
-                ),
-                S_full_accum=False,
+                desc="LOCO: kinship accumulation",
                 valid_indices=valid_indices,
             )
 
+            elapsed = time.perf_counter() - start_time
+            logger.info(
+                f"LOCO streaming accumulation complete in {elapsed:.2f}s, "
+                f"computing {len(S_chr)} LOCO matrices"
+            )
+
+            K_loco_buf = np.empty_like(S_full_np)
+            yield from _yield_loco_matrices(
+                S_full_np,
+                S_chr,
+                n_chr_filtered,
+                n_filtered,
+                K_loco_buf,
+                copy_output=_copy_yielded_matrices,
+            )
+            yield from _yield_full_kinship_fallback(
+                S_full_np, chrs_without_snps, n_filtered
+            )
+        else:
+            # === MULTI-PASS: batch chromosomes across disk passes ===
+            # S_full is computed once in pass 1; later passes accumulate only
+            # their batch's S_chr. batch_size was decided above.
+            n_batches = (n_chr_with_snps + batch_size - 1) // batch_size
+            logger.warning(
+                f"LOCO streaming: multi-pass mode ({n_batches} passes, "
+                f"{batch_size} chromosomes/pass). Single-pass would need "
+                f"{single_pass_gb:.1f}GB, available {available_gb:.1f}GB."
+            )
+
+            # First batch: compute S_full + first batch of S_chr
+            first_batch = chrs_with_snps[:batch_size]
+            S_full_np, S_chr = _stream_s_full_and_chr(
+                bed_path,
+                n_samples,
+                n_snps,
+                snp_indices,
+                chromosomes,
+                first_batch,
+                chunk_size,
+                show_progress,
+                desc=f"LOCO: pass 1/{n_batches} (S_full + {len(first_batch)} chr)",
+                valid_indices=valid_indices,
+            )
+
+            K_loco_buf = np.empty_like(S_full_np)
             yield from _yield_loco_matrices(
                 S_full_np,
                 S_chr,
@@ -1300,12 +1356,49 @@ def compute_loco_kinship_streaming(
             del S_chr
             gc.collect()
 
-        yield from _yield_full_kinship_fallback(
-            S_full_np, chrs_without_snps, n_filtered
-        )
+            # Subsequent batches: only accumulate S_chr (S_full already computed)
+            for batch_idx in range(1, n_batches):
+                batch_start = batch_idx * batch_size
+                batch_chrs = chrs_with_snps[batch_start : batch_start + batch_size]
 
-        elapsed = time.perf_counter() - start_time
-        logger.info(
-            f"LOCO multi-pass complete in {elapsed:.2f}s, "
-            f"{n_batches} passes over {n_chr_with_snps} chromosomes"
-        )
+                _, S_chr = _stream_s_full_and_chr(
+                    bed_path,
+                    n_samples,
+                    n_snps,
+                    snp_indices,
+                    chromosomes,
+                    batch_chrs,
+                    chunk_size,
+                    show_progress,
+                    desc=(
+                        f"LOCO: pass {batch_idx + 1}/{n_batches} "
+                        f"({len(batch_chrs)} chr)"
+                    ),
+                    S_full_accum=False,
+                    valid_indices=valid_indices,
+                )
+
+                yield from _yield_loco_matrices(
+                    S_full_np,
+                    S_chr,
+                    n_chr_filtered,
+                    n_filtered,
+                    K_loco_buf,
+                    copy_output=_copy_yielded_matrices,
+                )
+                del S_chr
+                gc.collect()
+
+            yield from _yield_full_kinship_fallback(
+                S_full_np, chrs_without_snps, n_filtered
+            )
+
+            elapsed = time.perf_counter() - start_time
+            logger.info(
+                f"LOCO multi-pass complete in {elapsed:.2f}s, "
+                f"{n_batches} passes over {n_chr_with_snps} chromosomes"
+            )
+
+    if return_snp_stats:
+        return _generate(), snp_stats_cache
+    return _generate()

--- a/src/jamma/lmm/loco.py
+++ b/src/jamma/lmm/loco.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import contextlib
 import gc
 import time
-from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -32,12 +31,14 @@ from jamma.core.threading import (
 from jamma.io.plink import (
     get_plink_metadata,
     partitions_from_metadata,
-    stream_genotype_chunks,
     validate_genotype_values,
 )
 from jamma.jlinalg import compute_snp_stats_chunk
-from jamma.kinship import write_kinship_matrix
-from jamma.kinship.missing import impute_and_center
+from jamma.kinship import (
+    SnpStatsCache,
+    compute_loco_kinship_streaming,
+    write_kinship_matrix,
+)
 from jamma.lmm.compute_numpy import compute_lmm_chunk_numpy
 from jamma.lmm.eigen import eigendecompose_kinship
 from jamma.lmm.eigen_io import read_eigen_files, write_eigen_files
@@ -57,47 +58,6 @@ from jamma.lmm.runner_numpy import compute_chunk_size_numpy
 from jamma.lmm.schema import RESULT_FIELDS, TEST_TYPE_MAP, LazySnpMeta, LocoResult
 from jamma.lmm.stats import AssocResult
 from jamma.utils import chr_sort_key
-
-
-@dataclass(frozen=True)
-class SnpStatsCache:
-    """Global SNP statistics from kinship streaming PASS 1.
-
-    Stores per-SNP means, missing counts, and variances for ALL SNPs in the
-    BIM file (unfiltered), computed over ALL samples (including those with
-    missing phenotypes). Per-chromosome stats are extracted by indexing
-    with chr_snp_indices: cache.col_means[chr_snp_indices].
-
-    The all-samples population matters: ``n_samples`` is the denominator for
-    miss_rate and the basis for col_means / col_vars. When filtering in the
-    association pass, use ``cache.n_samples`` — NOT n_valid — to match the
-    population the stats were computed from.
-
-    This eliminates 22+ per-chromosome BED re-reads in _collect_chr_snp_stats.
-    """
-
-    col_means: np.ndarray  # shape (n_snps_total,), float64
-    miss_counts: np.ndarray  # shape (n_snps_total,), int32
-    col_vars: np.ndarray  # shape (n_snps_total,), float64
-    n_samples: int  # sample count stats were computed over (ALL samples)
-
-    def __post_init__(self) -> None:
-        """Validate array shapes and freeze array contents."""
-        if not (self.col_means.shape == self.miss_counts.shape == self.col_vars.shape):
-            raise ValueError(
-                f"Array shape mismatch: col_means={self.col_means.shape}, "
-                f"miss_counts={self.miss_counts.shape}, "
-                f"col_vars={self.col_vars.shape}"
-            )
-        if self.col_means.ndim != 1:
-            raise ValueError(f"Expected 1-D arrays, got ndim={self.col_means.ndim}")
-        for arr in (self.col_means, self.miss_counts, self.col_vars):
-            arr.flags.writeable = False
-
-    @property
-    def n_snps(self) -> int:
-        """Number of SNPs in the cache (unfiltered BIM count)."""
-        return self.col_means.shape[0]
 
 
 def _collect_chr_snp_stats(
@@ -224,410 +184,6 @@ def _filter_chr_snps(
         filtered_miss,
         filtered_means,
     )
-
-
-def _compute_loco_kinship_streaming_numpy(
-    bed_path: Path,
-    chunk_size: int = 10_000,
-    maf_threshold: float = 0.0,
-    miss_threshold: float = 1.0,
-    check_memory: bool = True,
-    show_progress: bool = True,
-    ksnps_indices: np.ndarray | None = None,
-    valid_indices: np.ndarray | None = None,
-    _max_batch_chrs: int | None = None,
-    _copy_yielded_matrices: bool = True,
-) -> tuple[Iterator[tuple[str, np.ndarray]], SnpStatsCache]:
-    """Compute LOCO kinship matrices using pure NumPy.
-
-    Mirrors compute_loco_kinship_streaming from jamma.kinship but uses
-    np.matmul for accumulation. Supports multi-pass chromosome batching
-    when memory is insufficient for all S_chr simultaneously.
-
-    When valid_indices is provided, kinship matrices are computed at valid-sample
-    size (n_valid x n_valid) rather than full n_samples x n_samples, avoiding
-    full-matrix materialisation when there are missing-phenotype samples.
-
-    Args:
-        bed_path: Path prefix for PLINK files (without extension).
-        chunk_size: Number of SNPs per chunk (default 10,000).
-        maf_threshold: Minimum MAF for SNP inclusion.
-        miss_threshold: Maximum missing rate.
-        check_memory: If True, check available memory before allocation.
-        show_progress: If True, show progress bars.
-        ksnps_indices: Pre-resolved column indices for -ksnps restriction.
-        valid_indices: Row indices of valid samples. When provided, genotypes
-            are subsetted to these rows before accumulation so K_loco is
-            n_valid x n_valid. None means use all rows (full n_samples matrix).
-        _max_batch_chrs: Debug override for batch_size_chrs. When set, forces
-            multi-pass mode with at most this many chromosomes per pass. Used
-            by tests to verify multi-pass equivalence without mocking psutil.
-
-    Returns:
-        Tuple of (loco_iter, snp_stats_cache) where loco_iter yields
-        (chr_name, K_loco) pairs and snp_stats_cache holds global SNP
-        statistics from PASS 1. K_loco matrices are n_valid x n_valid when
-        valid_indices is provided.
-    """
-    import psutil
-
-    start_time = time.perf_counter()
-
-    meta = get_plink_metadata(bed_path)
-    n_samples = meta["n_samples"]
-    n_snps = meta["n_snps"]
-    chromosomes = meta["chromosome"]
-
-    if valid_indices is not None:
-        from jamma.kinship.compute import _validate_valid_indices
-
-        _validate_valid_indices(valid_indices, n_samples)
-
-    # Derive partitions from already-loaded metadata — avoids re-opening BED.
-    partitions = partitions_from_metadata(meta)
-    unique_chrs = sorted(partitions.keys(), key=chr_sort_key)
-
-    n_samples_kinship = len(valid_indices) if valid_indices is not None else n_samples
-    logger.info("Computing LOCO Kinship (streaming, NumPy)")
-    logger.info(
-        f"  Individuals: {n_samples_kinship:,}"
-        + (f" (filtered from {n_samples:,})" if n_samples_kinship != n_samples else "")
-    )
-    logger.info(f"  SNPs: {n_snps:,}")
-    logger.info(f"  Chromosomes: {len(unique_chrs)}")
-    logger.info(f"  Chunk size: {chunk_size:,}")
-
-    # Lazy import: progress_iterator pulls in tqdm (optional dependency)
-    if show_progress:
-        from jamma.core.progress import progress_iterator
-    n_chunks = (n_snps + chunk_size - 1) // chunk_size
-
-    # === PASS 1: SNP statistics for filtering ===
-    # Stats are computed on ALL samples (not valid_indices subset). This is
-    # intentional: the SnpStatsCache feeds the association pass which runs on
-    # all samples, and SNP filter decisions (MAF, missingness) should use the
-    # full population to match GEMMA's behaviour. The non-LOCO
-    # compute_kinship_streaming subsets in PASS 1 because it's standalone
-    # kinship where the caller has already decided which samples matter.
-    all_means = np.zeros(n_snps, dtype=np.float64)
-    all_miss_counts = np.zeros(n_snps, dtype=np.intp)
-    all_vars = np.zeros(n_snps, dtype=np.float64)
-    n_unexpected_total = 0
-
-    stats_iterator = stream_genotype_chunks(
-        bed_path, chunk_size=chunk_size, dtype=np.float32, show_progress=False
-    )
-    if show_progress:
-        stats_iterator = progress_iterator(
-            stats_iterator, total=n_chunks, desc="LOCO: SNP statistics (NumPy)"
-        )
-
-    for chunk, start, end in stats_iterator:
-        n_unexpected_total += validate_genotype_values(chunk)
-        chunk = np.ascontiguousarray(chunk)
-        compute_snp_stats_chunk(
-            chunk,
-            all_means[start:end],
-            all_miss_counts[start:end],
-            all_vars[start:end],
-        )
-        del chunk
-
-    if n_unexpected_total > 0:
-        logger.warning(
-            f"LOCO kinship genotype validation: {n_unexpected_total} values outside "
-            f"expected range {{0, 1, 2, NaN}}"
-        )
-
-    # Cache global stats for the association pass.
-    # Must be built BEFORE the del statements below destroy all_means / all_vars.
-    # n_samples is the population these stats were computed over (ALL rows).
-    snp_stats_cache = SnpStatsCache(
-        col_means=all_means.copy(),
-        miss_counts=all_miss_counts.copy(),
-        col_vars=all_vars.copy(),
-        n_samples=n_samples,
-    )
-
-    # Compute filters
-    miss_rates = all_miss_counts / n_samples
-    del all_miss_counts
-    allele_freqs = all_means / 2.0
-    del all_means
-    mafs = np.minimum(allele_freqs, 1.0 - allele_freqs)
-    is_polymorphic = all_vars > 0
-    del all_vars
-    snp_mask = (mafs >= maf_threshold) & (miss_rates <= miss_threshold) & is_polymorphic
-
-    if ksnps_indices is not None:
-        from jamma.core.snp_filter import apply_snp_list_mask
-
-        apply_snp_list_mask(snp_mask, ksnps_indices, n_snps, "Kinship SNP list")
-
-    n_filtered = int(np.sum(snp_mask))
-    if n_filtered == 0:
-        raise ValueError(
-            f"No SNPs passed filtering (maf>={maf_threshold}, "
-            f"miss<={miss_threshold}, polymorphic). "
-            f"Original SNP count: {n_snps}"
-        )
-
-    if n_filtered < n_snps:
-        n_removed = n_snps - n_filtered
-        logger.info(
-            f"LOCO kinship filtering: {n_filtered:,} SNPs retained, "
-            f"{n_removed:,} removed (MAF/missing/monomorphic)"
-        )
-
-    snp_indices = np.where(snp_mask)[0]
-    chr_for_filtered = chromosomes[snp_indices]
-
-    n_chr_filtered: dict[str, int] = {
-        chr_name: int(np.sum(chr_for_filtered == chr_name)) for chr_name in unique_chrs
-    }
-    chrs_with_snps = [c for c in unique_chrs if n_chr_filtered.get(c, 0) > 0]
-    chrs_without_snps = [c for c in unique_chrs if n_chr_filtered.get(c, 0) == 0]
-    if chrs_without_snps:
-        logger.warning(
-            f"{len(chrs_without_snps)} chromosome(s) have 0 ksnps after filtering: "
-            f"{chrs_without_snps}. LOCO will use full kinship for these "
-            f"(nothing to leave out)."
-        )
-
-    # Memory strategy: single-pass vs multi-pass chromosome batching.
-    from jamma.core.memory import _dsyevr_peak_gb
-
-    matrix_gb = n_samples_kinship**2 * 8 / 1e9
-    # Chunk buffer is n_samples (full BED rows) — subsetting happens after read.
-    chunk_buffer_gb = n_samples * chunk_size * 8 / 1e9
-    n_chr_with_snps = len(chrs_with_snps)
-    # S_full + K_loco_buf + all S_chr + chunk buffer
-    single_pass_gb = matrix_gb * (2 + n_chr_with_snps) + chunk_buffer_gb
-    available_gb = psutil.virtual_memory().available / 1e9
-    # Minimum: 3 matrices (S_full + K_loco_buf + 1 S_chr) + chunk buffer +
-    # eigendecomp workspace. This catches the case where even multi-pass with
-    # batch_size=1 won't fit. Eigendecomp runs while generator is suspended
-    # with S_chr still alive.
-    # Uses DSYEVR peak (smaller driver) — eigendecompose_kinship() falls back
-    # from DSYEVD to DSYEVR under memory pressure, making this self-consistent.
-    eigendecomp_min_gb = _dsyevr_peak_gb(n_samples_kinship)
-    min_required_gb = matrix_gb * 3 + chunk_buffer_gb + eigendecomp_min_gb
-
-    if check_memory and min_required_gb > available_gb * 0.9:
-        raise MemoryError(
-            f"Insufficient memory for NumPy LOCO kinship: need at least "
-            f"{min_required_gb:.1f}GB for S_full + K_loco_buf + one S_chr + "
-            f"eigendecomp ({eigendecomp_min_gb:.1f}GB), "
-            f"available {available_gb:.1f}GB"
-        )
-
-    # Determine batch size: _max_batch_chrs overrides memory-based sizing (tests).
-    # INVARIANT: accumulate_s_full must be True ONLY for the first pass (batch_idx==0).
-    # If True for subsequent passes, S_full is accumulated multiple times, corrupting
-    # all K_loco matrices — each K_loco would be subtracted from an inflated S_full.
-    if _max_batch_chrs is not None:
-        batch_size_chrs = _max_batch_chrs
-        single_pass = n_chr_with_snps <= batch_size_chrs
-    else:
-        single_pass = single_pass_gb <= available_gb * 0.9
-        if single_pass:
-            batch_size_chrs = n_chr_with_snps  # unused in single-pass branch
-        else:
-            # The consumer eigendecomposes each K_loco while the generator is
-            # suspended with remaining S_chr matrices still alive. Reserve
-            # eigendecomp workspace so the batch doesn't exhaust memory before
-            # eigendecomp can run.
-            eigendecomp_reserve_gb = _dsyevr_peak_gb(n_samples_kinship)
-            # S_full + K_loco_buf (2 matrices) + chunk buffer + eigendecomp workspace
-            usable_gb = (
-                available_gb * 0.9
-                - matrix_gb * 2
-                - chunk_buffer_gb
-                - eigendecomp_reserve_gb
-            )
-            batch_size_chrs = max(1, int(usable_gb / matrix_gb))
-
-    if not single_pass:
-        n_batches = (n_chr_with_snps + batch_size_chrs - 1) // batch_size_chrs
-        logger.warning(
-            f"LOCO streaming (NumPy): multi-pass mode ({n_batches} passes, "
-            f"{batch_size_chrs} chromosomes/pass). Single-pass would need "
-            f"{single_pass_gb:.1f}GB, available {available_gb:.1f}GB."
-        )
-
-    # Helper: stream one BED pass, accumulating S_full and selected S_chr matrices.
-    # When accumulate_s_full=False, S_full is untouched (subsequent passes).
-    _s_full_accumulated = False
-
-    def _stream_pass(
-        batch_chrs: list[str],
-        S_full_buf: np.ndarray,
-        accumulate_s_full: bool,
-        pass_desc: str,
-    ) -> dict[str, np.ndarray]:
-        """Stream genotype chunks for one pass, returning per-chromosome S_chr.
-
-        Args:
-            batch_chrs: Chromosome names to accumulate data for this pass.
-            S_full_buf: Pre-allocated S_full buffer; updated in-place when
-                accumulate_s_full=True, unchanged otherwise.
-            accumulate_s_full: Whether to add to S_full_buf this pass.
-                Must be True ONLY for the first pass. Subsequent passes with
-                accumulate_s_full=True would double-count SNPs in S_full,
-                corrupting all K_loco matrices.
-            pass_desc: Progress bar description string.
-
-        Returns:
-            Dict of {chr_name: S_chr_matrix} for batch_chrs.
-        """
-        nonlocal _s_full_accumulated
-        if accumulate_s_full:
-            if _s_full_accumulated:
-                raise RuntimeError(
-                    "S_full accumulation requested more than once. "
-                    "This would corrupt K_loco matrices by double-counting SNPs."
-                )
-            _s_full_accumulated = True
-
-        batch_chr_set = set(batch_chrs)
-        batch_S_chr: dict[str, np.ndarray] = {
-            c: np.zeros((n_samples_kinship, n_samples_kinship), dtype=np.float64)
-            for c in batch_chrs
-        }
-
-        accum_iter = stream_genotype_chunks(
-            bed_path, chunk_size=chunk_size, dtype=np.float64, show_progress=False
-        )
-        if show_progress:
-            accum_iter = progress_iterator(accum_iter, total=n_chunks, desc=pass_desc)
-
-        for chunk, file_start, file_end in accum_iter:
-            left = np.searchsorted(snp_indices, file_start, side="left")
-            right = np.searchsorted(snp_indices, file_end, side="left")
-            chunk_snp_global_indices = snp_indices[left:right]
-            chunk_filtered_local = chunk_snp_global_indices - file_start
-
-            if len(chunk_filtered_local) == 0:
-                continue
-
-            X_chunk = chunk[:, chunk_filtered_local].astype(np.float64)
-            # Early valid-sample subsetting: compute kinship at n_valid size.
-            if valid_indices is not None:
-                X_chunk = X_chunk[valid_indices, :]
-            X_centered = impute_and_center(X_chunk)
-
-            if accumulate_s_full:
-                S_full_buf += X_centered @ X_centered.T
-
-            chunk_chrs = chromosomes[chunk_snp_global_indices]
-            target_chrs_in_chunk = set(chunk_chrs) & batch_chr_set
-            for chr_name in target_chrs_in_chunk:
-                X_chr_part = X_centered[:, chunk_chrs == chr_name]
-                batch_S_chr[chr_name] += X_chr_part @ X_chr_part.T
-
-            del X_chunk, X_centered, chunk
-
-        return batch_S_chr
-
-    def _yield_batch(
-        S_full_buf: np.ndarray,
-        batch_data: dict[str, np.ndarray],
-        K_loco_buf: np.ndarray,
-    ) -> Iterator[tuple[str, np.ndarray]]:
-        """Yield (chr_name, K_loco) 2-tuples, one per chromosome.
-
-        K_loco is computed in-place via buffer reuse, then copied before
-        yielding so callers may freely materialise the iterator.
-        """
-        for chr_name in sorted(batch_data.keys(), key=chr_sort_key):
-            p_chr = n_chr_filtered[chr_name]
-            p_loco = n_filtered - p_chr
-            if p_loco == 0:
-                raise ValueError(
-                    f"Cannot compute LOCO kinship: all {n_filtered} filtered SNPs "
-                    f"are on chromosome '{chr_name}'."
-                )
-            np.subtract(S_full_buf, batch_data[chr_name], out=K_loco_buf)
-            K_loco_buf /= p_loco
-            logger.debug(
-                f"LOCO chr {chr_name}: {p_chr} SNPs excluded, {p_loco} SNPs retained"
-            )
-            del batch_data[chr_name]
-            yield (
-                chr_name,
-                K_loco_buf.copy() if _copy_yielded_matrices else K_loco_buf,
-            )
-
-    def _yield_matrices() -> Iterator[tuple[str, np.ndarray]]:
-        nonlocal S_full  # needed: S_full /= n_filtered is augmented assignment
-
-        if single_pass:
-            # === SINGLE-PASS: one disk read for S_full + all S_chr ===
-            batch_data = _stream_pass(
-                chrs_with_snps,
-                S_full,
-                accumulate_s_full=True,
-                pass_desc="LOCO: kinship accumulation (NumPy)",
-            )
-
-            elapsed = time.perf_counter() - start_time
-            logger.info(
-                f"LOCO streaming accumulation (NumPy) complete in {elapsed:.2f}s, "
-                f"computing {len(batch_data)} LOCO matrices"
-            )
-
-            yield from _yield_batch(S_full, batch_data, K_loco_buf)
-
-        else:
-            # === MULTI-PASS: batch chromosomes across disk passes ===
-            # Pass 0: accumulate S_full + first batch of S_chr (accumulate_s_full=True).
-            # Pass k>0: accumulate only batch S_chr (accumulate_s_full=False).
-            # CRITICAL: accumulate_s_full=True ONLY for pass 0. Setting it True for
-            # subsequent passes would double-count SNPs in S_full, corrupting K_loco.
-            n_batches = (n_chr_with_snps + batch_size_chrs - 1) // batch_size_chrs
-            for batch_idx in range(n_batches):
-                batch_start = batch_idx * batch_size_chrs
-                batch_chrs = chrs_with_snps[batch_start : batch_start + batch_size_chrs]
-                accumulate_s_full = batch_idx == 0
-
-                if accumulate_s_full:
-                    desc = f"LOCO: pass 1/{n_batches} (S_full + {len(batch_chrs)} chr)"
-                else:
-                    desc = (
-                        f"LOCO: pass {batch_idx + 1}/{n_batches} "
-                        f"({len(batch_chrs)} chr)"
-                    )
-
-                batch_data = _stream_pass(
-                    batch_chrs,
-                    S_full,
-                    accumulate_s_full=accumulate_s_full,
-                    pass_desc=desc,
-                )
-
-                yield from _yield_batch(S_full, batch_data, K_loco_buf)
-                del batch_data
-                gc.collect()
-
-            elapsed = time.perf_counter() - start_time
-            logger.info(
-                f"LOCO streaming multi-pass (NumPy) complete in {elapsed:.2f}s, "
-                f"{n_batches} passes over {n_chr_with_snps} chromosomes"
-            )
-
-        # Yield full kinship for chromosomes with 0 filtered SNPs.
-        if chrs_without_snps:
-            S_full /= n_filtered
-            for chr_name in sorted(chrs_without_snps, key=chr_sort_key):
-                logger.debug(
-                    f"LOCO chr {chr_name}: 0 SNPs after filtering, using full kinship"
-                )
-                yield (chr_name, S_full.copy())
-
-    S_full = np.zeros((n_samples_kinship, n_samples_kinship), dtype=np.float64)
-
-    K_loco_buf = np.empty_like(S_full)
-    return _yield_matrices(), snp_stats_cache
 
 
 def _find_loco_eigen_cache(
@@ -889,8 +445,9 @@ def run_lmm_loco(
         )
 
         if eigen_cache is None:
-            # Stream LOCO kinship matrices one at a time (pure NumPy).
-            loco_iter, snp_stats_cache = _compute_loco_kinship_streaming_numpy(
+            # Stream LOCO kinship matrices one at a time (pure NumPy), reusing
+            # the shared kinship streamer and its PASS-1 SNP statistics.
+            loco_iter, snp_stats_cache = compute_loco_kinship_streaming(
                 bed_path,
                 maf_threshold=maf_threshold,
                 miss_threshold=miss_threshold,
@@ -899,6 +456,7 @@ def run_lmm_loco(
                 ksnps_indices=ksnps_indices,
                 valid_indices=kinship_valid_indices,
                 _copy_yielded_matrices=False,
+                return_snp_stats=True,
             )
 
             # Create eigen output directory before the loop (once, not per-chr).

--- a/tests/test_loco_numpy.py
+++ b/tests/test_loco_numpy.py
@@ -323,7 +323,7 @@ def test_loco_numpy_multipass_equivalence():
     if not _LOCO_BFILE.with_suffix(".bed").exists():
         pytest.skip("gemma_loco fixture not available")
 
-    from jamma.lmm.loco import _compute_loco_kinship_streaming_numpy
+    from jamma.kinship import compute_loco_kinship_streaming
 
     phenotypes = load_phenotypes_from_fam(_LOCO_BFILE.with_suffix(".fam"))
 
@@ -337,8 +337,9 @@ def test_loco_numpy_multipass_equivalence():
 
     # Multi-pass: force batch_size_chrs=1 via debug override (_max_batch_chrs).
     # The fixture has 3 chromosomes, so this triggers 3 disk passes.
-    # We patch _compute_loco_kinship_streaming_numpy to inject _max_batch_chrs=1.
-    original_fn = _compute_loco_kinship_streaming_numpy
+    # We patch compute_loco_kinship_streaming (as imported into loco) to inject
+    # _max_batch_chrs=1.
+    original_fn = compute_loco_kinship_streaming
 
     def patched_fn(*args, **kwargs):
         kwargs["_max_batch_chrs"] = 1
@@ -350,7 +351,7 @@ def test_loco_numpy_multipass_equivalence():
 
     with patch.object(
         loco_module,
-        "_compute_loco_kinship_streaming_numpy",
+        "compute_loco_kinship_streaming",
         side_effect=patched_fn,
     ):
         loco_multi = run_lmm_loco(
@@ -384,13 +385,13 @@ def test_loco_numpy_multipass_equivalence():
 def test_loco_numpy_valid_sample_subsetting():
     """K_loco is computed at valid-sample size when valid_indices is provided.
 
-    Verifies LOCO-07: _compute_loco_kinship_streaming_numpy returns n_valid x n_valid
+    Verifies LOCO-07: compute_loco_kinship_streaming returns n_valid x n_valid
     kinship matrices when valid_indices is provided, rather than n_samples x n_samples.
     """
     if not _LOCO_BFILE.with_suffix(".bed").exists():
         pytest.skip("gemma_loco fixture not available")
 
-    from jamma.lmm.loco import _compute_loco_kinship_streaming_numpy
+    from jamma.kinship import compute_loco_kinship_streaming
 
     meta = get_plink_metadata(_LOCO_BFILE)
     n_samples = meta["n_samples"]
@@ -399,11 +400,12 @@ def test_loco_numpy_valid_sample_subsetting():
     valid_indices = np.arange(0, n_samples - 5)
     n_valid = len(valid_indices)
 
-    loco_iter, cache = _compute_loco_kinship_streaming_numpy(
+    loco_iter, cache = compute_loco_kinship_streaming(
         _LOCO_BFILE,
         check_memory=False,
         show_progress=False,
         valid_indices=valid_indices,
+        return_snp_stats=True,
     )
 
     for chr_name, K_loco in loco_iter:
@@ -423,7 +425,7 @@ def test_loco_numpy_show_progress_true():
     """NumPy LOCO with show_progress=True completes without error.
 
     Exercises the tqdm progress bars and logger.info calls in
-    _compute_loco_kinship_streaming_numpy and run_lmm_loco.
+    compute_loco_kinship_streaming and run_lmm_loco.
     Runs in NumPy-only CI.
     """
     if not _LOCO_BFILE.with_suffix(".bed").exists():


### PR DESCRIPTION
Audit finding #3 from the structural review.

## Problem

`loco.py` carried a **400-line** `_compute_loco_kinship_streaming_numpy` whose own docstring admitted it *"mirrors `compute_loco_kinship_streaming` from `jamma.kinship`"* — a near-verbatim clone of the canonical streaming LOCO-kinship function. The two had to be kept bit-for-bit in sync by hand (identical PASS-1 stats, filtering, memory-planning formulas, and `MemoryError` strings). The only real reason for the fork: the loco copy also returned a `SnpStatsCache` so the association pass could skip per-chromosome BED re-reads.

## Change

`kinship.compute_loco_kinship_streaming` becomes the single implementation:

- **`return_snp_stats`** → optionally returns `(iterator, SnpStatsCache)`. PASS-1 already computed those stats and discarded them; now it can hand them back. This required restructuring the generator into an outer function that returns an inner generator.
- **`_max_batch_chrs`** → the multi-pass test override that previously lived only on the loco clone, so multi-pass can be exercised without mocking psutil.
- **PASS-1 genotype validation** → was loco-only; now also covers the `-gk` kinship path (a pure additive range-check warning, no result change).
- **`SnpStatsCache`** moves to the `kinship` package (it is pure kinship PASS-1 output).

`loco.py` deletes its clone and calls the shared function with `return_snp_stats=True`. The `@`→`np.dot` difference between the two copies is bit-identical for 2-D float64 (both dispatch to the same BLAS GEMM).

`loco.py` **1459 → 1017 lines (−442)**; `kinship/compute.py` +93 (moved class + params). Net −349.

## Verification (parity-critical path — verified hard)

- **Bit-identity vs the pre-merge implementation**: every `K_loco` matrix (chr 1/2/3) and every `SnpStatsCache` field (`col_means`, `col_vars`, `miss_counts`, `n_samples`) is **bit-for-bit identical** on the `gemma_loco` fixture (verified by computing both implementations and `np.array_equal`).
- **tier2 GEMMA LOCO parity** (`test_loco_gemma_equivalence`) — passes.
- **Multi-pass equivalence** (single-pass == multi-pass, via the migrated `_max_batch_chrs` override) — passes.
- **Valid-sample subsetting** (n_valid × n_valid K_loco) — passes.
- Full default suite: 2090 passed, 10 skipped, 3 xfailed. The sole failure (`test_eigh_inplace`) is a pre-existing platform FP-tolerance issue unrelated to this change (fails identically on `master`).
- `ruff check` + `ruff format` clean; all pre-commit hooks pass.