### PR TITLE
refactor(cli): move -gk kinship orchestration into pipeline.compute_kinship

### DIFF
--- a/src/jamma/cli.py
+++ b/src/jamma/cli.py
@@ -16,13 +16,6 @@ from loguru import logger
 
 import jamma
 from jamma.core import OutputConfig
-from jamma.io import load_plink_binary
-from jamma.kinship import (
-    compute_kinship_streaming,
-    compute_standardized_kinship,
-    write_kinship_matrix,
-    write_loco_kinship_matrices,
-)
 from jamma.pipeline import PipelineConfig, PipelineRunner
 from jamma.utils import setup_logging, write_gemma_log
 
@@ -378,7 +371,7 @@ def _run_gk(
     ksnps_file: Path | None,
     legacy_text: bool = False,
 ) -> None:
-    """Run kinship matrix computation."""
+    """Run kinship matrix computation (thin shell over compute_kinship)."""
     if mode not in (1, 2):
         _cli_error(f"invalid kinship mode {mode}. Use -gk 1 or -gk 2.")
 
@@ -414,166 +407,58 @@ def _run_gk(
             "Use 'jamma -gk 2 -bfile X' without -loco for standardized kinship."
         )
 
-    # Log startup banner (kinship uses all samples, so n_analyzed == n_total)
-    from jamma.io.plink import get_plink_metadata as _get_meta
-
-    _meta = _get_meta(bfile)
-    PipelineRunner._log_banner(
-        n_total=_meta["n_samples"],
-        n_analyzed=_meta["n_samples"],
-        n_snps=_meta["n_snps"],
+    # Delegate the compute/write orchestration to the pipeline, mirroring how
+    # _run_lmm delegates to PipelineRunner.run().
+    pipeline_config = PipelineConfig(
+        bfile=bfile,
+        maf=maf,
+        miss=miss,
+        output_dir=config.outdir,
+        output_prefix=config.prefix,
+        check_memory=check_memory,
+        show_progress=True,
+        loco=loco,
+        write_eigen=write_eigen,
+        ksnps_file=ksnps_file,
+        legacy_text=legacy_text,
     )
 
-    # Resolve ksnps_file to indices if provided
-    ksnps_indices = None
-    if ksnps_file is not None:
-        try:
-            from jamma.io.plink import get_plink_metadata
-            from jamma.io.snp_list import (
-                read_snp_list_file,
-                resolve_snp_list_to_indices,
-            )
+    try:
+        result = PipelineRunner(pipeline_config).compute_kinship(mode)
+    except (FileNotFoundError, ValueError, MemoryError, OSError) as e:
+        logger.debug("Kinship computation failed with traceback:", exc_info=True)
+        _cli_error(str(e))
 
-            meta = get_plink_metadata(bfile)
-            ksnp_ids = read_snp_list_file(ksnps_file)
-            ksnps_indices = resolve_snp_list_to_indices(ksnp_ids, meta["sid"])
-        except (FileNotFoundError, ValueError) as e:
-            logger.debug("CLI operation failed with traceback:", exc_info=True)
-            _cli_error(str(e))
-        click.echo(
-            f"Kinship SNP list (-ksnps): {len(ksnps_indices)} of "
-            f"{meta['n_snps']} SNPs selected"
-        )
-
-    if loco:
-        # LOCO kinship mode: compute per-chromosome LOCO kinship matrices
-        from jamma.kinship import compute_loco_kinship_streaming
-
-        click.echo(f"Computing LOCO kinship matrices from {bfile}...")
-        kinship_start = time.perf_counter()
-
-        loco_iter = compute_loco_kinship_streaming(
-            bfile,
-            maf_threshold=maf,
-            miss_threshold=miss,
-            check_memory=check_memory,
-            show_progress=True,
-            ksnps_indices=ksnps_indices,
-            _copy_yielded_matrices=False,
-        )
-        written_paths = write_loco_kinship_matrices(
-            loco_iter,
-            output_dir=config.outdir,
-            prefix=config.prefix,
-            legacy_text=legacy_text,
-        )
-        kinship_time = time.perf_counter() - kinship_start
-
-        click.echo(
-            f"Wrote {len(written_paths)} LOCO kinship matrices in {kinship_time:.2f}s"
-        )
-        for p in written_paths:
+    # Summary (CLI-facing)
+    if result.is_loco:
+        click.echo(f"Wrote {len(result.kinship_paths)} LOCO kinship matrices")
+        for p in result.kinship_paths:
             click.echo(f"  {p}")
+    else:
+        click.echo(f"Kinship matrix written to {result.kinship_paths[0]}")
+        if result.eigen_paths is not None:
+            click.echo(f"Eigenvalues written to {result.eigen_paths[0]}")
+            click.echo(f"Eigenvectors written to {result.eigen_paths[1]}")
 
-        # Write log file
-        elapsed = time.perf_counter() - start_time
+    # Write GEMMA log file (CLI-only)
+    elapsed = time.perf_counter() - start_time
+    if result.is_loco:
         params = {
             "kinship_mode": "loco",
-            "n_chromosomes": len(written_paths),
+            "n_chromosomes": len(result.kinship_paths),
             "maf_threshold": maf,
             "miss_threshold": miss,
         }
-        timing = {"total": elapsed, "kinship": kinship_time}
-        log_path = write_gemma_log(config, params, timing, command_line)
-        click.echo(f"Log written to {log_path}")
-        return
-
-    # Standard kinship mode
-    kinship_start = time.perf_counter()
-
-    if mode == 1:
-        # Centered kinship: use streaming to avoid loading full genotype matrix
-        kinship_label = "centered"
-        click.echo(f"Computing {kinship_label} kinship matrix (streaming)...")
-        if maf > 0.0 or miss < 1.0:
-            click.echo(f"Filtering: MAF >= {maf}, missing rate <= {miss}")
-
-        K = compute_kinship_streaming(
-            bfile,
-            maf_threshold=maf,
-            miss_threshold=miss,
-            check_memory=check_memory,
-            show_progress=True,
-            ksnps_indices=ksnps_indices,
-        )
     else:
-        # Standardized kinship: requires full genotype matrix (no streaming variant)
-        kinship_label = "standardized"
-        click.echo(f"Loading PLINK data from {bfile}...")
-        try:
-            plink_data = load_plink_binary(bfile)
-        except (FileNotFoundError, ValueError, OSError) as e:
-            logger.debug("Loading PLINK data failed with traceback:", exc_info=True)
-            _cli_error(f"loading PLINK data: {e}")
-
-        click.echo(f"Loaded {plink_data.n_samples} samples, {plink_data.n_snps} SNPs")
-        click.echo(f"Computing {kinship_label} kinship matrix...")
-        if maf > 0.0 or miss < 1.0:
-            click.echo(f"Filtering: MAF >= {maf}, missing rate <= {miss}")
-
-        genotypes = plink_data.genotypes
-        if ksnps_indices is not None:
-            genotypes = genotypes[:, ksnps_indices]
-            click.echo(f"Using {genotypes.shape[1]} SNPs for kinship computation")
-
-        K = compute_standardized_kinship(
-            genotypes,
-            maf_threshold=maf,
-            miss_threshold=miss,
-            check_memory=check_memory,
-        )
-
-    kinship_time = time.perf_counter() - kinship_start
-    click.echo(f"{kinship_label.capitalize()} kinship computed in {kinship_time:.2f}s")
-
-    # Write kinship matrix
-    kinship_base = config.outdir / f"{config.prefix}.cXX.txt"
-    kinship_path = write_kinship_matrix(K, kinship_base, legacy_text=legacy_text)
-    click.echo(f"Kinship matrix written to {kinship_path}")
-
-    n_samples = K.shape[0]
-
-    # Eigendecompose and write if -eigen flag
-    if write_eigen:
-        from jamma.lmm.eigen import eigendecompose_kinship
-        from jamma.lmm.eigen_io import write_eigen_files
-
-        eigenvalues, eigenvectors = eigendecompose_kinship(K, check_memory=check_memory)
-        del K  # K may be overwritten by eigendecomp; prevent accidental reuse
-        d_path, u_path = write_eigen_files(
-            eigenvalues,
-            eigenvectors,
-            config.outdir,
-            config.prefix,
-            legacy_text=legacy_text,
-        )
-        click.echo(f"Eigenvalues written to {d_path}")
-        click.echo(f"Eigenvectors written to {u_path}")
-
-    # Calculate timing
-    end_time = time.perf_counter()
-    elapsed = end_time - start_time
-    n_snps = _meta["n_snps"]
-    params = {
-        "n_samples": n_samples,
-        "n_snps": n_snps,
-        "kinship_mode": mode,
-        "kinship_file": str(kinship_path),
-        "maf_threshold": maf,
-        "miss_threshold": miss,
-    }
-    timing = {"total": elapsed, "kinship": kinship_time}
-
+        params = {
+            "n_samples": result.n_samples,
+            "n_snps": result.n_snps,
+            "kinship_mode": mode,
+            "kinship_file": str(result.kinship_paths[0]),
+            "maf_threshold": maf,
+            "miss_threshold": miss,
+        }
+    timing = {"total": elapsed, "kinship": result.kinship_s}
     log_path = write_gemma_log(config, params, timing, command_line)
     click.echo(f"Log written to {log_path}")
 

--- a/src/jamma/pipeline.py
+++ b/src/jamma/pipeline.py
@@ -36,8 +36,11 @@ from jamma.io.plink import get_plink_metadata, validate_plink_dimensions
 from jamma.io.snp_list import read_snp_list_file, resolve_snp_list_to_indices
 from jamma.kinship import (
     compute_kinship_streaming,
+    compute_loco_kinship_streaming,
+    compute_standardized_kinship,
     read_kinship_matrix,
     write_kinship_matrix,
+    write_loco_kinship_matrices,
 )
 from jamma.lmm.eigen import eigendecompose_kinship
 from jamma.lmm.eigen_io import read_eigen_files, write_eigen_files
@@ -205,6 +208,35 @@ class PipelineResult:
     n_covariates: int = 1
     pve_estimate: float | None = None
     pve_se: float | None = None
+
+
+@dataclass
+class KinshipResult:
+    """Outcome of a kinship computation (the ``-gk`` path).
+
+    Returned by ``PipelineRunner.compute_kinship`` so the CLI can write its
+    GEMMA log and summary without owning the compute/write orchestration.
+
+    Attributes:
+        kinship_paths: Written kinship matrix paths. One entry for a standard
+            run; one per chromosome for LOCO.
+        eigen_paths: ``(eigenvalue_path, eigenvector_path)`` when ``write_eigen``
+            was set, else None. Always None for LOCO.
+        n_samples: Sample count of the computed kinship matrix.
+        n_snps: Total SNP count from PLINK metadata.
+        mode: Kinship mode (1=centered, 2=standardized).
+        is_loco: True when per-chromosome LOCO matrices were written.
+        kinship_s: Wall time spent computing (and, for LOCO, writing) the
+            kinship matrix.
+    """
+
+    kinship_paths: list[Path]
+    eigen_paths: tuple[Path, Path] | None
+    n_samples: int
+    n_snps: int
+    mode: int
+    is_loco: bool
+    kinship_s: float
 
 
 class _PhenoLoopOutcome(NamedTuple):
@@ -868,6 +900,137 @@ class PipelineRunner:
         logger.info(f"Execution plan: {plan.runner_name} ({plan.reason})")
 
         return self._run_inner(t_start, plan, requested)
+
+    def compute_kinship(self, mode: int) -> KinshipResult:
+        """Compute and write the kinship matrix (the ``-gk`` path).
+
+        Orchestrates kinship computation end-to-end so the CLI is a thin shell
+        (like ``run()`` for the ``-lmm`` path). Honours ``config.loco`` (writes
+        per-chromosome LOCO matrices), ``config.write_eigen`` (eigendecomposes
+        and writes the eigen files), and ``config.ksnps_file`` (restricts the
+        SNPs used). Caller-facing validation (mode range, file existence,
+        flag-combination guards) stays in the CLI.
+
+        Args:
+            mode: Kinship mode — 1 (centered, streaming) or 2 (standardized,
+                in-memory).
+
+        Returns:
+            A KinshipResult with the written paths, dimensions, and timing.
+        """
+        meta = get_plink_metadata(self.config.bfile)
+        n_samples = meta["n_samples"]
+        n_snps = meta["n_snps"]
+
+        # GEMMA-style banner — kinship uses all samples (n_analyzed == n_total).
+        self._log_banner(n_total=n_samples, n_analyzed=n_samples, n_snps=n_snps)
+
+        ksnps_indices = self._resolve_snp_list(
+            self.config.ksnps_file, meta["sid"], "-ksnps"
+        )
+
+        t_kinship = time.perf_counter()
+
+        if self.config.loco:
+            logger.info(f"Computing LOCO kinship matrices from {self.config.bfile}")
+            loco_iter = compute_loco_kinship_streaming(
+                self.config.bfile,
+                maf_threshold=self.config.maf,
+                miss_threshold=self.config.miss,
+                check_memory=self.config.check_memory,
+                show_progress=self.config.show_progress,
+                ksnps_indices=ksnps_indices,
+                _copy_yielded_matrices=False,
+            )
+            written_paths = write_loco_kinship_matrices(
+                loco_iter,
+                output_dir=self.config.output_dir,
+                prefix=self.config.output_prefix,
+                legacy_text=self.config.legacy_text,
+            )
+            kinship_s = time.perf_counter() - t_kinship
+            logger.info(
+                f"Wrote {len(written_paths)} LOCO kinship matrices in {kinship_s:.2f}s"
+            )
+            return KinshipResult(
+                kinship_paths=written_paths,
+                eigen_paths=None,
+                n_samples=n_samples,
+                n_snps=n_snps,
+                mode=mode,
+                is_loco=True,
+                kinship_s=kinship_s,
+            )
+
+        if self.config.maf > 0.0 or self.config.miss < 1.0:
+            logger.info(
+                f"Filtering: MAF >= {self.config.maf}, "
+                f"missing rate <= {self.config.miss}"
+            )
+
+        if mode == 1:
+            logger.info("Computing centered kinship matrix (streaming)")
+            K = compute_kinship_streaming(
+                self.config.bfile,
+                maf_threshold=self.config.maf,
+                miss_threshold=self.config.miss,
+                check_memory=self.config.check_memory,
+                show_progress=self.config.show_progress,
+                ksnps_indices=ksnps_indices,
+            )
+        else:
+            # Standardized kinship needs the full genotype matrix (no streaming).
+            from jamma.io import load_plink_binary
+
+            logger.info(f"Loading PLINK data from {self.config.bfile}")
+            plink_data = load_plink_binary(self.config.bfile)
+            genotypes = plink_data.genotypes
+            if ksnps_indices is not None:
+                genotypes = genotypes[:, ksnps_indices]
+                logger.info(f"Using {genotypes.shape[1]} SNPs for kinship computation")
+            logger.info("Computing standardized kinship matrix")
+            K = compute_standardized_kinship(
+                genotypes,
+                maf_threshold=self.config.maf,
+                miss_threshold=self.config.miss,
+                check_memory=self.config.check_memory,
+            )
+
+        kinship_s = time.perf_counter() - t_kinship
+
+        kinship_base = self.config.output_dir / f"{self.config.output_prefix}.cXX.txt"
+        kinship_path = write_kinship_matrix(
+            K, kinship_base, legacy_text=self.config.legacy_text
+        )
+        logger.info(f"Kinship matrix written to {kinship_path}")
+        n_out = K.shape[0]
+
+        eigen_paths: tuple[Path, Path] | None = None
+        if self.config.write_eigen:
+            eigenvalues, eigenvectors = eigendecompose_kinship(
+                K, check_memory=self.config.check_memory
+            )
+            del K  # K may be overwritten by eigendecomp; prevent accidental reuse
+            d_path, u_path = write_eigen_files(
+                eigenvalues,
+                eigenvectors,
+                self.config.output_dir,
+                self.config.output_prefix,
+                legacy_text=self.config.legacy_text,
+            )
+            eigen_paths = (d_path, u_path)
+            logger.info(f"Eigenvalues written to {d_path}")
+            logger.info(f"Eigenvectors written to {u_path}")
+
+        return KinshipResult(
+            kinship_paths=[kinship_path],
+            eigen_paths=eigen_paths,
+            n_samples=n_out,
+            n_snps=n_snps,
+            mode=mode,
+            is_loco=False,
+            kinship_s=kinship_s,
+        )
 
     def _load_phenotypes_and_intersect_masks(
         self,


### PR DESCRIPTION
## What

`_run_gk` inlined the entire kinship compute/write pipeline in the CLI layer (metadata, ksnps resolution, the centered/standardized/LOCO branches, matrix writing, optional eigendecomposition). `_run_lmm`, by contrast, is a thin shell: build a `PipelineConfig`, call `PipelineRunner(config).run()`, write the GEMMA log from the result.

This brings `-gk` to the same shape (audit finding **#7**):

- **`PipelineRunner.compute_kinship(mode)`** now owns the orchestration and returns a **`KinshipResult`** (written paths, dims, timing). It reuses the existing `_log_banner` / `_resolve_snp_list` helpers and logs progress via loguru like the rest of the pipeline — the pipeline layer must not import `click` (it also backs the Python API).
- **`_run_gk`** keeps only CLI concerns: flag-combination validation, the result summary, and the GEMMA log file. `cli.py` sheds its direct kinship/plink imports (net −157 lines).

Pure orchestration move — no behaviour change.

## Verification

- **End-to-end `-gk` parity** across twelve invocations — centered (mode 1), standardized (mode 2), `--legacy-text`, `-eigen` for both modes, `-ksnps` subset, `-loco` (19 chromosomes), and five error paths (bad bfile, missing ksnps, `-gk 2 -loco`, `-eigen -loco`, bad mode). Every produced kinship/eigen output is byte-identical to the prior code (**31 files sha256-matched**), with identical exit codes and error output.
- **Full suite**: 2090 passed, 10 skipped, 3 xfailed. The lone failure (`test_eigh_inplace_correctness`) is the pre-existing macOS Accelerate DSYEVD FP-tolerance artifact, fails identically on master, unrelated to this change.

Completes the #6/#7 pipeline/CLI decomposition pair (#6 was #31).