### PR TITLE
fix(docs): exclude canonical gnu.org license URLs from link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -37,6 +37,10 @@ exclude = [
     # legacy cert chain frequently 5xx or HandshakeFailure for CI bots.
     "^http://fsf\\.org/?$",
     "^http://www\\.gnu\\.org/philosophy/why-not-lgpl",
+    # Canonical GPL/FSF license URLs in LICENSE.md and the README badge.
+    # gnu.org regularly times out for CI bots; these are well-known
+    # boilerplate links with no value in verifying.
+    "^https?://www\\.gnu\\.org/licenses",
 ]
 
 # Don't attempt to verify mailto: links — lychee defaults to false but


### PR DESCRIPTION
## Summary

Fixes #25. The weekly external link check flagged timeouts on two canonical GPL/FSF boilerplate URLs:

- `http://www.gnu.org/licenses/` — LICENSE.md GPL boilerplate
- `https://www.gnu.org/licenses/gpl-3.0` — README license badge

gnu.org regularly times out for CI bots. These are well-known boilerplate links with no value in verifying. Added them to the lychee `exclude` list, consistent with the existing `why-not-lgpl` and `fsf.org` excludes.

## Verification

```
lychee --no-progress --config lychee.toml LICENSE.md README.md
🔍 45 Total ✅ 41 OK 🚫 0 Errors 👻 4 Excluded
```

Closes #25