### PR TITLE
docs: refresh documentation for post-5.3.0 refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,38 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal refactors (no behavior change)**: extracted shared helpers and
+  decomposed large methods across the LMM runners and pipeline. None of these
+  alter CLI flags, output, or numerical results:
+  - `validation/compare.py`: `.assoc.txt` parsing and comparison now derived
+    from the output schema rather than hand-maintained column lists (434549f).
+  - `lmm`: data-driven accel-symbol loader + shared streaming dispatch (#26);
+    LOCO kinship streaming merged into the canonical kinship function (#27);
+    shared `_create_workspaces` (#28), `_dispatch_compute` (#29), and
+    `_drive_pipeline` (#30) extracted from both batch and streaming runners;
+    per-thread scratch alloc/free helpers extracted in `_lmm_accel.c` (#33).
+  - `pipeline.py`: `PipelineRunner._run_inner` god-method decomposed (#31);
+    `-gk` kinship orchestration moved into `pipeline.compute_kinship` (#32).
+- **Dependencies**: bump build-system `numpy` pin 2.4.4 → 2.4.5 (#24);
+  bump `j178/prek-action` 2.0.3 → 2.0.4 (#23) and
+  `google/osv-scanner-action` 2.3.5 → 2.3.8 (#22).
+
+### Fixed
+
+- **LOCO multi-pass eigendecomp reserve sizing**: size the eigendecomposition
+  workspace reserve by valid-sample count rather than the unfiltered sample
+  count, so multi-pass LOCO batch sizing reflects the post-filter matrix
+  dimension (#34).
+- **Link check**: exclude canonical `gnu.org` license URLs from the lychee
+  link check (`lychee.toml`) — gnu.org regularly times out for CI bots,
+  producing spurious failures in the weekly external link check (#35).
+
 ## [5.3.0] - 2026-04-29
 
 ### Added
 
 - **Weekly ASAN/UBSAN sanitizer workflow** (`.github/workflows/sanitizer.yml`):
-  rebuilds C extensions with `-fsanitize=address,undefined` and runs the test
-  suite under both sanitizers every Sunday. Uses a sentinel meta-test
-  (`JAMMA_SENTINEL_UB=1` injects `-DJAMMA_SENTINEL_UB`, triggering a known
-  heap-OOB) to verify the sanitizer harness is actually catching bugs and not
-  silently passing. CI workflow runs with `set -o pipefail`, ASAN traces are
-  written to a file rather than piped, and the sentinel asserter accepts both
-  ASan heap-OOB and UBSan out-of-bounds signatures.
-- **`JAMMA_SANITIZE` build seam** in `_build_support/compile_and_link.py`:
-  appends `-fsanitize=...` flags and disables the post-link import probe so
-  sanitized builds don't crash the wheel-build subprocess. Wired into all
-  three compile entry points (`hatch_build.py`, `_compile_jlinalg.py`,
-  `_compile_accel.py`). `check-compile-flag-literals.py` extended to recognise
-  sanitizer flag literals so they are not flagged by the lint hook.
-- **`JAMMA_FORCE_NUMPY_FALLBACK` env-var gate** for `jlinalg` and `lmm`:
-  forces the NumPy fallback path even when vendor BLAS is available. Used by
-  the sanitizer workflow to exercise the pure-Python paths and by debugging
-  workflows where vendor-LAPACK output needs to be cross-checked against
-  NumPy reference. Documented in `docs/TESTING.md` §1.10.
-- **Sanitizer suppression file** for ASan and the heap-OOB sentinel
-  (`-DJAMMA_SENTINEL_UB`). Documented in `docs/TESTING.md` §1.10 "Running
-  under sanitizers (local repro of CI)".
-- **New pre-commit hooks** (commit `2745846`): actionlint (GitHub Actions
-  workflow lint), zizmor (workflow security audit), shellcheck (shell-script
-  lint), vulture (dead-code detection), refurb (Python refactor suggestions),
-  and `pytest-rerunfailures` (test re-run on transient failure). Three
-  categories of pre-existing findings are deferred — see project notes for
-  triage status and tightening conditions for each hook. (`.github/workflows/sanitizer.yml`):
   rebuilds C extensions with `-fsanitize=address,undefined` and runs the test
   suite under both sanitizers every Sunday. Uses a sentinel meta-test
   (`JAMMA_SENTINEL_UB=1` injects `-DJAMMA_SENTINEL_UB`, triggering a known

--- a/docs/CODEMAP.md
+++ b/docs/CODEMAP.md
@@ -171,11 +171,12 @@ Two user-facing entry points: the `gwas()` API for programmatic use and the CLI 
 | ID | Component | Description | File:Line |
 |----|-----------|-------------|-----------|
 | 1a | `main()` | Click command — all flags (`-gk`, `-lmm`, `-bfile`, `-o`, `-outdir`) | [cli.py](../src/jamma/cli.py) |
-| 1a | `_run_gk()` | Kinship computation (`-gk 1`) | [cli.py](../src/jamma/cli.py) |
-| 1a | `_run_lmm()` | LMM association (`-lmm 1/2/3/4`) | [cli.py](../src/jamma/cli.py) |
+| 1a | `_run_gk()` | Kinship CLI shell (`-gk 1/2`); delegates compute/write to `PipelineRunner.compute_kinship()` | [cli.py:360](../src/jamma/cli.py#L360) |
+| 1a | `_run_lmm()` | LMM association (`-lmm 1/2/3/4`) | [cli.py:466](../src/jamma/cli.py#L466) |
 | 1b | `gwas()` | One-call GWAS pipeline (load -> kinship -> LMM -> results) | [gwas.py:40](../src/jamma/gwas.py#L40) |
 | 1b | `GWASResult` | Pipeline result dataclass (associations, timing, counts) | [gwas.py:22](../src/jamma/gwas.py#L22) |
 | 1c | `PipelineRunner` | Shared orchestration (validate -> parse -> memory -> kinship -> LMM); passes `valid_indices` for early sample filtering when `save_kinship=False` | [pipeline.py](../src/jamma/pipeline.py) |
+| 1c | `PipelineRunner.compute_kinship()` | `-gk` kinship orchestration (compute + write), returns `KinshipResult` | [pipeline.py:904](../src/jamma/pipeline.py#L904) |
 | 1c | `PipelineConfig` | Pipeline configuration dataclass (all CLI flags) | [pipeline.py](../src/jamma/pipeline.py) |
 
 ---
@@ -214,9 +215,10 @@ GEMMA algorithm reimplementation: kinship -> eigendecomp -> REML -> test statist
 
 | ID | Component | Description | File:Line |
 |----|-----------|-------------|-----------|
-| 3a | `compute_centered_kinship()` | K = (1/p) x Xc x Xc' in batches of 10k SNPs | [compute.py:205](../src/jamma/kinship/compute.py#L205) |
-| 3a | `compute_kinship_streaming()` | 2-pass streaming (stats -> accumulate); accepts `valid_indices` for early sample filtering | [compute.py:519](../src/jamma/kinship/compute.py#L519) |
-| 3a | `_filter_snps()` | MAF, missing rate, monomorphism filters | [compute.py:79](../src/jamma/kinship/compute.py#L79) |
+| 3a | `compute_centered_kinship()` | K = (1/p) x Xc x Xc' in batches of 10k SNPs | [compute.py:247](../src/jamma/kinship/compute.py#L247) |
+| 3a | `compute_kinship_streaming()` | 2-pass streaming (stats -> accumulate); accepts `valid_indices` for early sample filtering; canonical streaming kinship (LOCO streaming merged in) | [compute.py:564](../src/jamma/kinship/compute.py#L564) |
+| 3a | `compute_loco_kinship_streaming()` | Streaming per-chromosome LOCO kinship matrices | [compute.py:1124](../src/jamma/kinship/compute.py#L1124) |
+| 3a | `_filter_snps()` | MAF, missing rate, monomorphism filters | [compute.py:122](../src/jamma/kinship/compute.py#L122) |
 | 3b | `impute_and_center()` | NaN -> mean, then center (in-place for NumPy arrays) | [missing.py:21](../src/jamma/kinship/missing.py#L21) |
 | 3b | `impute_missing_inplace()` | In-place NaN -> col-mean for genotype chunks (used by all runners) | [lmm/impute.py:6](../src/jamma/lmm/impute.py#L6) |
 | 3c | `eigendecompose_kinship()` | Eigendecomp via `jlinalg.eigh` with BLAS thread control | [eigen.py](../src/jamma/lmm/eigen.py) |
@@ -256,20 +258,23 @@ Pure-NumPy LMM implementation. Works on all platforms (Intel Mac, Windows, Linux
 | 4Na | `batch_calc_wald_stats_numpy()` | Vectorized Wald: REML optimize -> beta, SE, p_wald | [likelihood_numpy.py](../src/jamma/lmm/likelihood_numpy.py) |
 | 4Na | `batch_calc_score_stats_numpy()` | Vectorized Score: null lambda -> p_score | [likelihood_numpy.py](../src/jamma/lmm/likelihood_numpy.py) |
 | 4Na | `_batch_lrt_pvalues_numpy()` | Vectorized LRT: MLE optimize -> p_lrt | [likelihood_numpy.py](../src/jamma/lmm/likelihood_numpy.py) |
-| 4Nb | `run_lmm_association_numpy()` | In-memory batch runner (full genotype load) | [runner_numpy.py](../src/jamma/lmm/runner_numpy.py) |
-| 4Nc | `_compute_lmm_chunk_numpy()` | Per-chunk dispatch for NumPy backend | [compute_numpy.py](../src/jamma/lmm/compute_numpy.py) |
-| 4Nd | `compute_wald_stats_workspace()` | C extension: OpenMP Wald test with workspace API | [_lmm_accel.c](../src/jamma/lmm/_lmm_accel.c) |
+| 4Nb | `run_lmm_association_numpy()` | In-memory batch runner (full genotype load) | [runner_numpy.py:1016](../src/jamma/lmm/runner_numpy.py#L1016) |
+| 4Nb | `_create_workspaces()` / `_dispatch_compute()` / `_drive_pipeline()` | Shared runner helpers (workspace alloc, chunk dispatch, rotate-and-compute loop); used by both batch and streaming runners | [runner_numpy.py:196](../src/jamma/lmm/runner_numpy.py#L196) |
+| 4Nc | `create_lmm_workspace()` | Allocate reusable per-chunk Wald workspace (split C path) | [compute_numpy.py:514](../src/jamma/lmm/compute_numpy.py#L514) |
+| 4Nc | `compute_wald_split_c_ws()` | Workspace-based Wald compute dispatch to C extension | [compute_numpy.py:557](../src/jamma/lmm/compute_numpy.py#L557) |
+| 4Nd | `compute_lmm_batch_c()` | C extension: batch REML Wald pipeline for n_cvt=1 with OpenMP | [_lmm_accel.c](../src/jamma/lmm/_lmm_accel.c) |
+| 4Nd | `alloc_thread_scratch()` / `free_thread_scratch()` | C: per-thread scratch buffer alloc/free helpers | [_lmm_accel.c:127](../src/jamma/lmm/_lmm_accel.c#L127) |
 | 4Nd | `_compile_accel.py` | Dev-mode / runtime recompile for `_lmm_accel` | [_compile_accel.py](../src/jamma/lmm/_compile_accel.py) |
 | 4Nd | `_compile_jlinalg.py` | Dev-mode / runtime recompile for jlinalg | [_compile_jlinalg.py](../src/jamma/jlinalg/_compile_jlinalg.py) |
 | 4Nd | `compile_and_link.py` | Shared compile flags, source lists, link flags (single source of truth, consumed by `hatch_build.py` + both `_compile_*.py`) | [compile_and_link.py](../src/jamma/_build_support/compile_and_link.py) |
-| 4Ne | `run_lmm_association_numpy_streaming()` | NumPy disk streaming (two-pass, full pipeline support, C extension) | [runner_numpy_streaming.py:103](../src/jamma/lmm/runner_numpy_streaming.py#L103) |
-| 4Nf | `select_execution_mode()` | Batch vs streaming mode selection | [runner.py:74](../src/jamma/lmm/runner.py#L74) |
-| 4Nf | `run_lmm()` | Unified dispatch to all runners | [runner.py:183](../src/jamma/lmm/runner.py#L183) |
+| 4Ne | `run_lmm_association_numpy_streaming()` | NumPy disk streaming (two-pass, full pipeline support, C extension) | [runner_numpy_streaming.py:104](../src/jamma/lmm/runner_numpy_streaming.py#L104) |
+| 4Nf | `select_execution_mode()` | Batch vs streaming mode selection | [runner.py:108](../src/jamma/lmm/runner.py#L108) |
+| 4Nf | `run_lmm()` | Unified dispatch to all runners | [runner.py:209](../src/jamma/lmm/runner.py#L209) |
 | 4Nh | `StatColumn` | Frozen dataclass for output column definitions | [lmm/schema.py:17](../src/jamma/lmm/schema.py#L17) |
 | 4Nh | `ModeSpec` | Per-mode column specification (single source of truth) | [lmm/schema.py:43](../src/jamma/lmm/schema.py#L43) |
 | 4Ni | `_build_results()` | Table-driven result building from numpy arrays | [lmm/results.py:43](../src/jamma/lmm/results.py#L43) |
 | 4Ni | `count_lambda_boundary_hits()` | Diagnostic: count SNPs at lambda bounds | [lmm/results.py:185](../src/jamma/lmm/results.py#L185) |
-| 4Nj | `run_lmm_loco()` | LOCO: per-chromosome kinship -> eigen -> LMM | [lmm/loco.py](../src/jamma/lmm/loco.py) |
+| 4Nj | `run_lmm_loco()` | LOCO: per-chromosome kinship -> eigen -> LMM | [lmm/loco.py:242](../src/jamma/lmm/loco.py#L242) |
 
 ---
 
@@ -308,12 +313,12 @@ Tolerance-based comparison infrastructure for GEMMA parity testing.
 | ID | Component | Description | File:Line |
 |----|-----------|-------------|-----------|
 | 6a | `ToleranceConfig` | Per-field tolerance dataclass (strict/default/relaxed) | [tolerances.py:40](../src/jamma/validation/tolerances.py#L40) |
-| 6b | `ComparisonResult` | Pass/fail with max diffs and worst location | [compare.py:20](../src/jamma/validation/compare.py#L20) |
-| 6b | `AssocComparisonResult` | Per-column comparison results | [compare.py:501](../src/jamma/validation/compare.py#L501) |
-| 6b | `compare_assoc_results()` | Full association comparison across test types | [compare.py:536](../src/jamma/validation/compare.py#L536) |
-| 6b | `compare_kinship_matrices()` | Symmetric matrix comparison | [compare.py:143](../src/jamma/validation/compare.py#L143) |
-| 6b | `load_gemma_assoc()` | Parse GEMMA `.assoc.txt` | [compare.py:205](../src/jamma/validation/compare.py#L205) |
-| 6b | `load_gemma_kinship()` | Parse GEMMA `.cXX.txt` | [compare.py:181](../src/jamma/validation/compare.py#L181) |
+| 6b | `ComparisonResult` | Pass/fail with max diffs and worst location | [compare.py:21](../src/jamma/validation/compare.py#L21) |
+| 6b | `AssocComparisonResult` | Per-column comparison results | [compare.py:304](../src/jamma/validation/compare.py#L304) |
+| 6b | `compare_assoc_results()` | Full association comparison across test types | [compare.py:391](../src/jamma/validation/compare.py#L391) |
+| 6b | `compare_kinship_matrices()` | Symmetric matrix comparison | [compare.py:144](../src/jamma/validation/compare.py#L144) |
+| 6b | `load_gemma_assoc()` | Parse GEMMA `.assoc.txt` (schema-derived) | [compare.py:250](../src/jamma/validation/compare.py#L250) |
+| 6b | `load_gemma_kinship()` | Parse GEMMA `.cXX.txt` | [compare.py:182](../src/jamma/validation/compare.py#L182) |
 
 ---
 
@@ -542,12 +547,12 @@ Priority order: `JAMMA_BACKEND` env var -> `--backend` CLI flag -> auto (batch i
 |------|-------------|
 | gwas() API | [gwas.py:40](../src/jamma/gwas.py#L40) |
 | PipelineRunner | [pipeline.py](../src/jamma/pipeline.py) |
-| CLI dispatch | [cli.py:54](../src/jamma/cli.py#L54) |
+| CLI dispatch | [cli.py:46](../src/jamma/cli.py#L46) |
 | Load genotypes | [plink.py:53](../src/jamma/io/plink.py#L53) |
 | SNP list I/O | [io/snp_list.py](../src/jamma/io/snp_list.py) |
 | Eigen I/O | [lmm/eigen_io.py](../src/jamma/lmm/eigen_io.py) |
 | Matrix writer | [io/matrix_writer.py:91](../src/jamma/io/matrix_writer.py#L91) |
-| Kinship compute | [compute.py:204](../src/jamma/kinship/compute.py#L204) |
+| Kinship compute | [compute.py:247](../src/jamma/kinship/compute.py#L247) |
 | Eigendecomposition | [eigen.py](../src/jamma/lmm/eigen.py) |
 | REML likelihood | [likelihood.py:356](../src/jamma/lmm/likelihood.py#L356) |
 | Lambda optimization | [likelihood_numpy.py](../src/jamma/lmm/likelihood_numpy.py) |
@@ -566,6 +571,6 @@ Priority order: `JAMMA_BACKEND` env var -> `--backend` CLI flag -> auto (batch i
 | Memory estimation | [memory.py:197](../src/jamma/core/memory.py#L197) |
 | Threading | [threading.py:30](../src/jamma/core/threading.py#L30) |
 | Hardware context | [hardware.py:21](../src/jamma/core/hardware.py#L21) |
-| Validation comparison | [compare.py:536](../src/jamma/validation/compare.py#L536) |
+| Validation comparison | [compare.py:391](../src/jamma/validation/compare.py#L391) |
 | Equivalence proof | [GEMMA_EQUIVALENCE.md](GEMMA_EQUIVALENCE.md) |
 | Numerical equivalence bound | [GEMMA_NUMERICAL_EQUIVALENCE_BOUND.md](GEMMA_NUMERICAL_EQUIVALENCE_BOUND.md) |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,6 +17,7 @@ use — the defaults are appropriate for most analyses.
 | `JAMMA_NO_TELEMETRY` | *(unset)* | Set to any non-empty value to disable local benchmark telemetry. |
 | `DO_NOT_TRACK` | *(unset)* | Universal convention: set to `1` to disable JAMMA telemetry. |
 | `JLINALG_NO_VENDOR_LAPACK` | *(unset)* | Set to any non-empty value (not `0`) to force `np.linalg.eigh` instead of vendor LAPACK (DSYEVD/DSYEVR) for eigendecomposition only (scope: `lmm/eigen.py`). Useful for debugging numerical differences. |
+| `JLINALG_DISPATCH_DEBUG` | *(unset)* | Set to `1` to print jlinalg BLAS dispatch diagnostics (backend detection, ILP64 status, library path) from the `jlinalg` C layer. Debug aid only. |
 | `JAMMA_FORCE_NUMPY_FALLBACK` | *(unset)* | Set to any non-empty value (not `0`) to force the **entire jlinalg layer** onto its NumPy fallback path even when vendor BLAS is loaded. Wider scope than `JLINALG_NO_VENDOR_LAPACK`: also affects `dgemm`, `dsyrk`, `dsyr2k`, `qr`, `svd`. Used by the weekly sanitizer workflow and by full numerical-divergence debugging. |
 | `JAMMA_NO_OPENMP` | *(unset)* | Set to any non-empty value (not `0`) to disable OpenMP when compiling the C extension. The extension will be single-threaded. |
 | `OMP_NUM_THREADS` | *(system default)* | OpenMP thread count for C extension kernels (`_lmm_accel`, `_jlinalg`). Separate from `JAMMA_BLAS_THREADS`, which controls BLAS only. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -61,10 +61,13 @@ line-length = 88
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B"]
+select = [
+    "E", "F", "I", "UP", "B",
+    "SIM", "RUF", "C4", "PIE", "PERF", "NPY", "PT", "PTH", "BLE",
+]
 ```
 
-This covers pyflakes (`F`), pycodestyle (`E`), isort import sorting (`I`), pyupgrade (`UP`), and flake8-bugbear (`B`).
+This covers pyflakes (`F`), pycodestyle (`E`), isort import sorting (`I`), pyupgrade (`UP`), flake8-bugbear (`B`), flake8-simplify (`SIM`), ruff-specific checks (`RUF`), flake8-comprehensions (`C4`), flake8-pie (`PIE`), perflint (`PERF`), numpy-specific rules (`NPY`), flake8-pytest-style (`PT`), flake8-use-pathlib (`PTH`), and flake8-blind-except (`BLE`). See `pyproject.toml` for the per-rule `ignore` list.
 
 Pre-commit hooks run ruff on staged files automatically. A pre-push hook runs `ruff format --check .` across all files to catch drift in unstaged files. To fix locally before pushing:
 

--- a/docs/GEMMA_DIVERGENCES.md
+++ b/docs/GEMMA_DIVERGENCES.md
@@ -476,9 +476,9 @@ still written as binary `.npy` only:
   ([loco.py](../src/jamma/lmm/loco.py), eigen write block).
 - LOCO kinship saves are hard-coded to `.loco.cXX.chr{chr}.npy`
   ([loco.py](../src/jamma/lmm/loco.py), `save_kinship` block).
-- `PipelineRunner._run_inner` forwards every relevant LOCO option to
+- `PipelineRunner._run_loco` forwards every relevant LOCO option to
   `run_lmm_loco` except `legacy_text`
-  ([src/jamma/pipeline.py](../src/jamma/pipeline.py), LOCO dispatch block).
+  ([src/jamma/pipeline.py](../src/jamma/pipeline.py), `_run_loco` LOCO dispatch block).
 
 ### Impact
 

--- a/docs/JLINALG_ARCHITECTURE.md
+++ b/docs/JLINALG_ARCHITECTURE.md
@@ -146,8 +146,9 @@ There are no hand-rolled LAPACK implementations in the tree. As of commit
 `663a22b` (`refactor: strip JAX and own-BLAS`), the architectural commitment
 is **vendor ILP64 LAPACK > NumPy fallback** with nothing in between -- if
 vendor LAPACK is unavailable on a target platform, jlinalg falls through to
-NumPy, never to a translated C routine. The `STRICT_IEEE_SOURCES` tuple in
-`_build_support/compile_and_link.py` is empty for this reason.
+NumPy, never to a translated C routine. The `LAPACK_SOURCES` tuple in
+`_build_support/compile_and_link.py` holds only the `eigh.c` dispatcher (it
+gets strict IEEE 754 flags) -- no translated LAPACK routines are listed.
 
 ### Test Infrastructure
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -161,7 +161,7 @@ computation.
 |----------|---------|-------------|
 | `ci.yml` → `lint` | push/PR | `prek run --all-files` |
 | `ci.yml` → `test` (Linux 3.11/3.12, ARM Mac 3.12, Linux MKL ILP64) | push/PR | `pytest -m "not tier2 and not slow and not benchmark" -v -n 3` |
-| `ci.yml` → `coverage` | push/PR | `slipcover --fail-under 80 -m pytest ... -n0` plus per-subsystem floors via `scripts/check_subsystem_coverage.py` (jlinalg 18%, lmm/io/core all 80%) |
+| `ci.yml` → `coverage` | push/PR | `slipcover --fail-under 80 -m pytest ... -n0` plus per-subsystem floors via `scripts/check_subsystem_coverage.py` (lmm 80%, jlinalg 18%, kinship 50%, io 80%) |
 | `test-slow.yml` | push to master | `pytest -m "tier2 or slow" -v -o 'addopts=' --no-cov` |
 | `sanitizers.yml` | Wednesday cron + dispatch | `pytest -m "not benchmark and not slow" -n 0 -p no:randomly` (under ASAN/UBSAN) |
 | `flaky-detect.yml` | Sunday 06:00 UTC + dispatch | `pytest` under five distinct `--randomly-seed` values, opens an issue on disagreement |
@@ -295,9 +295,8 @@ catch. The carve-out is:
 
 | Allowed structural test | Why behavior tests can't replace it |
 |---|---|
-| `_mm256_zeroupper()` / `vzeroupper` present in AVX2 kernel source ([`tests/test_jlinalg_dgemm.py:562`](../tests/test_jlinalg_dgemm.py#L562)) | Missing this corrupts SSE registers in *callers'* code, not in our test |
-| No `abort()` calls in translated LAPACK C ([`tests/test_jlinalg_eigh.py:1489`](../tests/test_jlinalg_eigh.py#L1489)) | An `abort()` SIGKILLs the process; pytest cannot catch it as a failure |
-| `loco.py` uses `raise RuntimeError`, not bare `assert` ([`tests/test_safety_gates.py:263`](../tests/test_safety_gates.py#L263)) | `python -O` strips bare `assert`; behavior-only test passes in dev and silently breaks in prod |
+| `_mm256_zeroupper()` / `vzeroupper` present in AVX2 kernel source ([`tests/test_jlinalg_dgemm.py:568`](../tests/test_jlinalg_dgemm.py#L568)) | Missing this corrupts SSE registers in *callers'* code, not in our test |
+| LOCO iterator-None guard uses `raise RuntimeError`, not bare `assert` ([`tests/test_safety_gates.py:311`](../tests/test_safety_gates.py#L311)) | `python -O` strips bare `assert`; behavior-only test passes in dev and silently breaks in prod |
 | Compile-flag literals not in three forbidden entry points ([`scripts/check-compile-flag-literals.py`](../scripts/check-compile-flag-literals.py)) | Drift between `hatch_build.py` and runtime recompile produces ABI mismatch at runtime |
 
 **Rules for adding a new structural source test:**
@@ -469,8 +468,8 @@ Run with `uv run pytest tests/test_hypothesis.py -x`.
 
 ### 3.4 Suite-wide stats (snapshot)
 
-- 81 test files, ~38.5k lines.
-- Largest: `test_lmm_accel.py` (6,271 lines) — should be split by tier and concern.
+- 85 test files, ~39k lines.
+- Largest: `test_lmm_accel.py` (~6,240 lines) — should be split by tier and concern.
 - ~178 `skip`/`skipif`/`xfail` calls — most legitimate (vendor LAPACK, optional fixtures).
 - 8 files use `@patch`/`MagicMock` (~31 occurrences). Most are at allowed boundaries; the violations called out in §3.2 are the exceptions.
 - `inspect.getsource()`: zero uses. The ban holds.

--- a/docs/WHY_JAMMA.md
+++ b/docs/WHY_JAMMA.md
@@ -218,7 +218,7 @@ The goal is a **drop-in replacement**: same CLI, same output format, same scient
 from jamma.utils.logging import log_rss_memory
 
 log_rss_memory("kinship", "before")  # Logs current RSS in GB
-kinship = compute_kinship(genotypes)
+kinship = compute_centered_kinship(genotypes)
 log_rss_memory("kinship", "after")
 ```
 


### PR DESCRIPTION
## Summary

Verified-audit pass over **all** project docs against the current codebase, reflecting the internal refactors merged since v5.3.0 (#26–#34) and the link-check fix (#35). No production behavior changed — these are documentation-currency fixes only.

Conducted as a parallel multi-agent audit (6 disjoint doc groups), with every changed claim independently re-verified against source before commit.

## Changes

| File | Fix |
|------|-----|
| CHANGELOG.md | Populate empty `[Unreleased]`; de-duplicate an accidentally-pasted block in `[5.3.0]` Added |
| docs/CODEMAP.md | Correct line anchors shifted by refactors; add `pipeline.compute_kinship` + shared runner helpers; replace removed/renamed LMM workspace symbols |
| docs/CONFIGURATION.md | Document undocumented `JLINALG_DISPATCH_DEBUG` env var |
| docs/DEVELOPMENT.md | Expand documented ruff `select` set to match pyproject.toml |
| docs/GEMMA_DIVERGENCES.md | `_run_inner` → `_run_loco` after #31 decomposition |
| docs/JLINALG_ARCHITECTURE.md | Stale `STRICT_IEEE_SOURCES` → actual `LAPACK_SOURCES = ("eigh.c",)` |
| docs/TESTING.md | Fix coverage-floor list (lmm 80 / jlinalg 18 / kinship 50 / io 80); drop obsolete translated-LAPACK abort row; refresh line anchors + suite stats |
| docs/WHY_JAMMA.md | `compute_kinship` → `compute_centered_kinship` in API snippet |

## Verification

- Every line-number anchor, symbol name, env var, coverage floor, and count was confirmed against source (not taken on the agents' word).
- Offline lychee link check: `0 Errors`. markdownlint + maid (mermaid) pass.
- Audit also surfaced docs that were already correct (ARCHITECTURE, GEMMA_EQUIVALENCE, JLINALG_ALGORITHMS, PERFORMANCE, GETTING-STARTED, DEPLOYMENT, GLOSSARY, README, CONTRIBUTING, USER_GUIDE, jlinalg/README) — left unchanged.

## Notes

- One audit agent initially over-stepped scope and began implementing a `legacy_text` LOCO feature in `loco.py`/`pipeline.py` plus a test; that source change was reverted — this PR is docs-only.
- The numpy-mkl ILP64 wheel version references (README, USER_GUIDE) were deliberately kept at 2.4.4: the dependabot #24 bump touched only the build-time `numpy==2.4.5` pin, which is independent of the external numpy-mkl wheel index.