### PR TITLE
fix(loco): make Python eigen-cache API work and honor --legacy-text

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,11 @@ result = gwas("data/my_study", kinship_file="k.txt", covariate_file="covars.txt"
 # LOCO analysis (leave-one-chromosome-out)
 result = gwas("data/my_study", loco=True)
 
-# LOCO with eigen caching (skip eigendecomp on subsequent runs)
-result = gwas("data/my_study", loco=True, write_eigen=True)
-# Reuse cached eigen files from a previous run
-result = gwas("data/my_study", loco=True,
-              eigenvalue_file="output/result.eigenD.npy",
-              eigenvector_file="output/result.eigenU.npy")
+# LOCO with eigen caching: writes a per-chromosome eigen cache to output_dir
+result = gwas("data/my_study", loco=True, write_eigen=True, output_dir="output")
+# Reusing a LOCO eigen cache on a later run is CLI-only — the cache is a set of
+# per-chromosome files keyed by directory, so point --eigen-dir at the same dir:
+#   jamma -lmm 1 -bfile data/my_study -loco --eigen-dir output -o result
 
 # Multi-phenotype with eigendecomp reuse (Python API)
 result = gwas("data/my_study", write_eigen=True, phenotype_column=1)

--- a/docs/GEMMA_DIVERGENCES.md
+++ b/docs/GEMMA_DIVERGENCES.md
@@ -457,51 +457,20 @@ the `save_kinship=False` path. This is a memory optimization, not a numerical ch
 
 ---
 
-## 13. LOCO Ignores `--legacy-text` for Eigen and Kinship Artifacts
+## 13. LOCO `--legacy-text` Support (Resolved)
 
-Section 11 documents JAMMA's contract: `--legacy-text` produces GEMMA-compatible
-text files (`.cXX.txt`, `.eigenD.txt`, `.eigenU.txt`). That contract holds on the
-standard (non-LOCO) code path but **does not currently hold on the LOCO path**.
+This was previously a divergence: `--legacy-text` was honored on the standard
+code path but ignored on the LOCO path, so `--loco --legacy-text --write-eigen`
+silently produced binary `.npy` artifacts instead of the GEMMA-compatible
+`.cXX.txt` / `.eigenD.txt` / `.eigenU.txt` files the user asked for.
 
-### Observed behaviour
-
-When `--loco` is combined with `--legacy-text`, LOCO eigen and kinship artifacts are
-still written as binary `.npy` only:
-
-- `run_lmm_loco()` does not accept a `legacy_text` parameter
-  ([src/jamma/lmm/loco.py](../src/jamma/lmm/loco.py)).
-- LOCO eigen cache lookup hard-codes the binary default
-  ([loco.py](../src/jamma/lmm/loco.py), `_find_loco_eigen_cache`).
-- LOCO eigen writes call `write_eigen_files(...)` without `legacy_text=True`
-  ([loco.py](../src/jamma/lmm/loco.py), eigen write block).
-- LOCO kinship saves are hard-coded to `.loco.cXX.chr{chr}.npy`
-  ([loco.py](../src/jamma/lmm/loco.py), `save_kinship` block).
-- `PipelineRunner._run_inner` forwards every relevant LOCO option to
-  `run_lmm_loco` except `legacy_text`
-  ([src/jamma/pipeline.py](../src/jamma/pipeline.py), LOCO dispatch block).
-
-### Impact
-
-A user who passes `--loco --legacy-text --write-eigen` will receive `.npy` files
-instead of the `.eigenD.txt` / `.eigenU.txt` files they asked for. The same holds
-for per-chromosome LOCO kinship saves. No error is raised; the binary files are
-simply not GEMMA-compatible. Downstream GEMMA-driven consumers of those artifacts
-will fail.
-
-Numerical results (associations, p-values) are unaffected — this is a file-format
-divergence only.
-
-### Status
-
-Documented here as a known gap rather than fixed in the same patch, because the fix
-requires threading `legacy_text` through four call sites and adding LOCO-specific
-cache-lookup logic for `.txt` siblings. Tracked separately.
-
-### Workaround
-
-Run the standard (non-LOCO) path with `--legacy-text --write-eigen` if you need
-GEMMA-compatible text artifacts. Use `--loco` only when binary `.npy` artifacts are
-acceptable, or consume the LOCO `.npy` files via `numpy.load`.
+**Fixed.** `run_lmm_loco()` now accepts a `legacy_text` parameter and threads it
+through the per-chromosome eigen-cache lookup (`_find_loco_eigen_cache`), the
+kinship save (filename suffix + `write_kinship_matrix`), and the eigen write
+(`write_eigen_files`). `PipelineRunner._run_loco` forwards
+`config.legacy_text`, so `--loco --legacy-text` now writes GEMMA text artifacts
+on the LOCO path identically to the standard path. As with the non-LOCO path,
+text mode writes the `.txt` files plus `.npy` sidecars for fast reload.
 
 ---
 
@@ -522,7 +491,7 @@ acceptable, or consume the LOCO `.npy` files via `numpy.load`.
 | LOCO + external kinship | Silently uses full K | Rejects (mutual exclusion) | Correctness guard |
 | Default file format | Text (`.cXX.txt`, `.eigenD.txt`) | Binary `.npy` (`--legacy-text` for text) | GEMMA files read natively |
 | Early sample filtering | Kinship always n × n | Kinship at n_valid × n_valid when save_kinship=False | Memory saving only; values identical |
-| LOCO + `--legacy-text` | N/A (GEMMA has no LOCO) | Ignored on LOCO path — eigen/kinship still written as `.npy`; see §13 | File-format only, no numerical impact |
+| LOCO + `--legacy-text` | N/A (GEMMA has no LOCO) | Honored on LOCO path — writes `.cXX.txt` / `.eigenD.txt` / `.eigenU.txt` (see §13) | Parity with standard path |
 
 ---
 

--- a/src/jamma/lmm/loco.py
+++ b/src/jamma/lmm/loco.py
@@ -260,6 +260,7 @@ def run_lmm_loco(
     write_eigen: bool = False,
     eigen_dir: Path | None = None,
     eigen_prefix: str = "result",
+    legacy_text: bool = False,
 ) -> LocoResult:
     """Run LOCO LMM association: per-chromosome eigendecomp and association.
 
@@ -303,6 +304,9 @@ def run_lmm_loco(
             When set, checks for cached files before computing. Combined
             with write_eigen, writes new files here.
         eigen_prefix: Prefix for eigen filenames (default "result").
+        legacy_text: If True, write (and look up) per-chromosome kinship and
+            eigen artifacts as GEMMA-compatible text files (.cXX.txt,
+            .eigenD.txt, .eigenU.txt) instead of binary .npy.
     Returns:
         LocoResult with associations in biological chromosome order
         (1-22, X, Y, XY, MT). Associations list is empty if output_path
@@ -413,7 +417,9 @@ def run_lmm_loco(
         # (re)generate files, so skip the cache and recompute.
         eigen_cache: dict[str, tuple[Path, Path]] | None = None
         if eigen_dir is not None and not write_eigen:
-            eigen_cache = _find_loco_eigen_cache(eigen_dir, eigen_prefix, unique_chrs)
+            eigen_cache = _find_loco_eigen_cache(
+                eigen_dir, eigen_prefix, unique_chrs, legacy_text=legacy_text
+            )
             if eigen_cache is not None:
                 logger.info(
                     f"Found complete LOCO eigen cache in {eigen_dir} "
@@ -518,12 +524,15 @@ def run_lmm_loco(
                     )
 
                 if save_kinship and kinship_output_dir is not None:
+                    kinship_suffix = ".txt" if legacy_text else ".npy"
+                    kinship_stem = f"{kinship_output_prefix}.loco.cXX.chr{chr_name}"
                     kinship_path = (
-                        kinship_output_dir
-                        / f"{kinship_output_prefix}.loco.cXX.chr{chr_name}.npy"
+                        kinship_output_dir / f"{kinship_stem}{kinship_suffix}"
                     )
                     try:
-                        actual_path = write_kinship_matrix(K_loco, kinship_path)
+                        actual_path = write_kinship_matrix(
+                            K_loco, kinship_path, legacy_text=legacy_text
+                        )
                     except OSError as e:
                         raise OSError(
                             f"Failed to save LOCO kinship for chromosome "
@@ -565,6 +574,7 @@ def run_lmm_loco(
                         U,
                         eigen_dir,
                         prefix=f"{eigen_prefix}.loco.chr{chr_name}",
+                        legacy_text=legacy_text,
                     )
                 except OSError as e:
                     raise OSError(

--- a/src/jamma/pipeline.py
+++ b/src/jamma/pipeline.py
@@ -172,6 +172,13 @@ class PipelineConfig:
                 "(-n with multiple columns). "
                 "Run each phenotype separately."
             )
+        # LOCO writes a per-chromosome eigen cache keyed by eigen_dir. When the
+        # caller asks to write eigen but gives no directory, default it to
+        # output_dir so the Python API matches the CLI (which applies the same
+        # default) instead of raising in run_lmm_loco. The non-LOCO write_eigen
+        # path writes to output_dir directly and never consults eigen_dir.
+        if self.loco and self.write_eigen and self.eigen_dir is None:
+            self.eigen_dir = self.output_dir
 
 
 @dataclass
@@ -1545,6 +1552,7 @@ class PipelineRunner:
             write_eigen=self.config.write_eigen,
             eigen_dir=self.config.eigen_dir,
             eigen_prefix=self.config.output_prefix,
+            legacy_text=self.config.legacy_text,
         )
         loco_s = time.perf_counter() - t_loco
         total_s = time.perf_counter() - t_start

--- a/tests/test_loco_eigen_cache.py
+++ b/tests/test_loco_eigen_cache.py
@@ -414,3 +414,150 @@ class TestEigenDirCLI:
             lmm_mode=1,
         )
         assert config.eigen_dir is None
+
+
+class TestLocoWriteEigenAutoDefault:
+    """PipelineConfig defaults eigen_dir for LOCO write_eigen (Python API parity).
+
+    The CLI defaults --eigen-dir to the output directory when -loco -eigen
+    is set; the Python API (gwas / PipelineConfig) must do the same so that
+    ``gwas(..., loco=True, write_eigen=True)`` does not raise. Regression
+    test for the broken eigen-cache API.
+    """
+
+    def test_loco_write_eigen_defaults_eigen_dir_to_output_dir(self) -> None:
+        """loco + write_eigen + no eigen_dir → eigen_dir becomes output_dir."""
+        from jamma.pipeline import PipelineConfig
+
+        config = PipelineConfig(
+            bfile=Path("dummy"),
+            lmm_mode=1,
+            loco=True,
+            write_eigen=True,
+            output_dir=Path("out"),
+        )
+        assert config.eigen_dir == Path("out")
+
+    def test_explicit_eigen_dir_not_overridden(self) -> None:
+        """An explicitly supplied eigen_dir is preserved, not defaulted."""
+        from jamma.pipeline import PipelineConfig
+
+        config = PipelineConfig(
+            bfile=Path("dummy"),
+            lmm_mode=1,
+            loco=True,
+            write_eigen=True,
+            output_dir=Path("out"),
+            eigen_dir=Path("custom_eigen"),
+        )
+        assert config.eigen_dir == Path("custom_eigen")
+
+    def test_non_loco_write_eigen_does_not_default_eigen_dir(self) -> None:
+        """Standard (non-LOCO) write_eigen leaves eigen_dir as None.
+
+        The non-LOCO path writes eigen files to output_dir directly and never
+        consults eigen_dir, so it must stay None.
+        """
+        from jamma.pipeline import PipelineConfig
+
+        config = PipelineConfig(
+            bfile=Path("dummy"),
+            lmm_mode=1,
+            loco=False,
+            write_eigen=True,
+            output_dir=Path("out"),
+        )
+        assert config.eigen_dir is None
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not _mouse_hs1940_exists(), reason="mouse_hs1940 fixture not available"
+)
+class TestGwasLocoWriteEigen:
+    """End-to-end: gwas(loco=True, write_eigen=True) without eigen_dir works.
+
+    Regression for the broken Python eigen-cache API: this call previously
+    raised ``ValueError: write_eigen=True requires eigen_dir to be set``
+    because the API never defaulted eigen_dir the way the CLI does.
+    """
+
+    def test_gwas_loco_write_eigen_writes_eigen_to_output_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """No eigen_dir given: per-chr eigen files land in output_dir."""
+        from jamma import gwas
+        from jamma.io.plink import get_plink_metadata, partitions_from_metadata
+
+        out_dir = tmp_path / "out"
+        result = gwas(
+            str(MOUSE_HS1940_BFILE),
+            loco=True,
+            write_eigen=True,
+            output_dir=str(out_dir),
+            check_memory=False,
+            show_progress=False,
+        )
+        assert result.n_snps_tested > 0
+
+        meta = get_plink_metadata(MOUSE_HS1940_BFILE)
+        unique_chrs = sorted(partitions_from_metadata(meta).keys())
+        for ch in unique_chrs:
+            assert (out_dir / f"result.loco.chr{ch}.eigenD.npy").exists(), (
+                f"Missing eigenD for chr {ch} in output_dir"
+            )
+            assert (out_dir / f"result.loco.chr{ch}.eigenU.npy").exists(), (
+                f"Missing eigenU for chr {ch} in output_dir"
+            )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not _mouse_hs1940_exists(), reason="mouse_hs1940 fixture not available"
+)
+class TestLocoLegacyText:
+    """LOCO honors legacy_text for kinship and eigen artifacts.
+
+    Regression test for GEMMA_DIVERGENCES §13: --legacy-text was ignored on
+    the LOCO path, producing .npy instead of GEMMA-compatible .txt files.
+    """
+
+    def test_run_lmm_loco_legacy_text_writes_txt_artifacts(
+        self, tmp_path: Path
+    ) -> None:
+        """legacy_text=True writes .txt eigen and kinship files."""
+        from jamma.io.plink import get_plink_metadata, partitions_from_metadata
+        from jamma.lmm.loco import run_lmm_loco
+        from tests.conftest import load_phenotypes_from_fam
+
+        fam_path = MOUSE_HS1940_BFILE.with_suffix(".fam")
+        phenotypes = load_phenotypes_from_fam(fam_path)
+        meta = get_plink_metadata(MOUSE_HS1940_BFILE)
+        unique_chrs = sorted(partitions_from_metadata(meta).keys())
+
+        run_lmm_loco(
+            bed_path=MOUSE_HS1940_BFILE,
+            phenotypes=phenotypes,
+            lmm_mode=1,
+            output_path=tmp_path / "result.assoc.txt",
+            check_memory=False,
+            show_progress=False,
+            save_kinship=True,
+            kinship_output_dir=tmp_path,
+            kinship_output_prefix="result",
+            write_eigen=True,
+            eigen_dir=tmp_path,
+            eigen_prefix="result",
+            legacy_text=True,
+        )
+
+        for ch in unique_chrs:
+            assert (tmp_path / f"result.loco.chr{ch}.eigenD.txt").exists(), (
+                f"Missing .txt eigenD for chr {ch}"
+            )
+            assert (tmp_path / f"result.loco.chr{ch}.eigenU.txt").exists(), (
+                f"Missing .txt eigenU for chr {ch}"
+            )
+            assert (tmp_path / f"result.loco.cXX.chr{ch}.txt").exists(), (
+                f"Missing .txt kinship for chr {ch}"
+            )


### PR DESCRIPTION
## Problem

Two live, user-facing bugs on the LOCO path:

**High — Python LOCO eigen-cache API broken.** The README advertises `gwas(..., loco=True, write_eigen=True)`, but `gwas()` never set `eigen_dir`, so the call raised `ValueError: write_eigen=True requires eigen_dir to be set`. The CLI works around this by defaulting `eigen_dir` to the output dir; the Python API did not. The README's LOCO eigen-*reuse* example was also wrong twice over: `gwas(loco=True, eigenvalue_file=..., eigenvector_file=...)` is rejected in LOCO mode, and LOCO has no single `eigenD`/`eigenU` to reuse — its cache is per-chromosome, keyed by directory.

**Medium — `--legacy-text` ignored on LOCO artifacts.** `run_lmm_loco` did not accept `legacy_text`, and `_run_loco` never forwarded `config.legacy_text`, so `--loco --legacy-text` silently wrote binary `.npy` instead of the GEMMA-compatible `.txt` the docs promise. Already documented as a known divergence (GEMMA_DIVERGENCES §13) but still a live bug.

## Fix

- **eigen_dir auto-default** centralized in `PipelineConfig.__post_init__`: when `loco and write_eigen and eigen_dir is None`, default `eigen_dir → output_dir` (matches the CLI; the Python API now works). Non-LOCO `write_eigen` is untouched (it writes to `output_dir` directly and never consults `eigen_dir`).
- **`legacy_text` threaded** through `run_lmm_loco` → per-chromosome eigen-cache lookup, kinship save (filename suffix + `write_kinship_matrix`), and `write_eigen_files`; `_run_loco` forwards `config.legacy_text`.
- **README** LOCO example corrected (write to `output_dir`; reuse via CLI `--eigen-dir`).
- **GEMMA_DIVERGENCES §13** + summary-table row marked Resolved.

The CLI's own `eigen_dir` default (`cli.py:509-511`) is now redundant with `__post_init__` but left in place — idempotent; removing it is unrelated cleanup.

## Tests

Added to `tests/test_loco_eigen_cache.py`:
- `TestLocoWriteEigenAutoDefault` (fast): `eigen_dir` auto-defaults for LOCO `write_eigen`; explicit `eigen_dir` preserved; non-LOCO path stays `None`.
- `TestGwasLocoWriteEigen` (slow): end-to-end `gwas(loco=True, write_eigen=True)` writes the per-chromosome cache to `output_dir`.
- `TestLocoLegacyText` (slow): `--loco` + `legacy_text=True` writes `.cXX.txt` / `.eigenD.txt` / `.eigenU.txt`.

`50 passed` across the three LOCO suites (incl. both slow regressions); `ruff check` + `ruff format --check` clean.