### PR TITLE
ci: add CodeQL SAST and security policy

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,92 @@
+name: CodeQL
+
+# Static analysis (SAST) for both languages in the tree:
+#
+#   * python  — taint/security queries over src/jamma and scripts
+#   * c-cpp   — the real untrusted-input surface: the PLINK .bed/.bim/.fam
+#               readers and _lmm_accel.c / _jlinalg.so. A malformed or
+#               hostile genotype file is the one attacker-controlled path
+#               into a numerical library, so the C extensions get static
+#               taint analysis here.
+#
+# Complements, not duplicates, the existing posture:
+#   * zizmor / actionlint   — workflow-level audit (not source code)
+#   * Sanitizers (ASAN/UBSAN) — runtime memory bugs, but only on paths the
+#                               test suite exercises; CodeQL reaches every
+#                               C path statically.
+#   * OSV scanner           — known-CVE dependency scanning, not first-party code
+#
+# Runs on PR/push to the default branches plus a weekly cron so queries
+# updated by GitHub between PRs still get applied to the tree. Results
+# land in the repo Security tab (Code scanning alerts).
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      # required for CodeQL to upload results
+      security-events: write
+      # required to read the Actions workflow run for the analysis
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: c-cpp
+            build-mode: manual
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@84498526a009a99c875e83ef4821a8ba52de7c22  # codeql-bundle-v2.25.5
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # The c-cpp analysis runs in manual build mode: CodeQL traces the
+      # actual compiler invocations, so we reproduce CI's two compile
+      # entry points exactly (see CLAUDE.md "_build_support" gotcha).
+      # python uses build-mode: none and skips this block.
+      - name: Install uv
+        if: matrix.language == 'c-cpp'
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Set up Python 3.12
+        if: matrix.language == 'c-cpp'
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        if: matrix.language == 'c-cpp'
+        run: uv sync
+
+      - name: Compile C extensions (_lmm_accel + jlinalg)
+        if: matrix.language == 'c-cpp'
+        run: |
+          uv run python -m jamma.lmm._compile_accel
+          uv run python -m jamma.jlinalg._compile_jlinalg
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@84498526a009a99c875e83ef4821a8ba52de7c22  # codeql-bundle-v2.25.5
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Supported versions
+
+JAMMA is published to PyPI from `master`. Security fixes are released against
+the latest published version only; there are no long-term support branches.
+Always run the most recent release.
+
+## Reporting a vulnerability
+
+Please report security issues **privately** — do not open a public issue for a
+suspected vulnerability.
+
+- Use GitHub's [private vulnerability reporting](https://github.com/michael-denyer/jamma/security/advisories/new)
+  ("Report a vulnerability" in the **Security** tab), or
+- email the maintainer at <mdenyer@gmail.com> with `JAMMA SECURITY` in the subject.
+
+Please include:
+
+- the JAMMA version (`jamma --version`) and how it was installed (PyPI wheel,
+  source, ILP64 numpy-mkl build);
+- a minimal reproduction — ideally the input files (or a description of their
+  shape) that trigger the issue;
+- the observed behaviour (crash, hang, memory corruption, incorrect result) and
+  what you expected.
+
+You can expect an acknowledgement within a few days. Fixes are prioritised by
+severity and coordinated via a GitHub security advisory.
+
+## Scope and threat model
+
+JAMMA is a numerical library for GWAS, not a network service. The relevant
+attack surface is **untrusted input files** processed by the native code:
+
+- the PLINK `.bed` / `.bim` / `.fam` readers, and
+- the C extensions (`_lmm_accel`, `jlinalg`) that consume parsed genotype data.
+
+Reports most likely to be in scope:
+
+- memory-safety issues in the C extensions (buffer overflow, out-of-bounds
+  read/write, integer overflow in size arithmetic) reachable from a crafted or
+  malformed input file;
+- denial of service from pathological inputs (unbounded allocation, hangs)
+  triggered by file contents rather than by the operator's chosen parameters.
+
+Generally **out of scope**:
+
+- resource exhaustion from legitimately large but well-formed datasets — JAMMA
+  is designed to consume the memory its inputs require (see the memory
+  estimators and `docs/USER_GUIDE.md`);
+- the optional runtime recompilation path, which invokes a compiler the
+  operator already trusts on inputs the operator controls;
+- vulnerabilities in third-party dependencies — report those upstream
+  (JAMMA's lockfile is scanned daily by OSV).
+
+If you are unsure whether something is in scope, report it anyway and we will
+triage.


### PR DESCRIPTION
## What

- **CodeQL workflow** (`.github/workflows/codeql.yml`) — static analysis for both languages in the tree:
  - `python` — taint/security queries over `src/jamma` and `scripts`
  - `c-cpp` — the untrusted-input surface: PLINK `.bed/.bim/.fam` readers and `_lmm_accel` / `jlinalg`. A crafted or malformed genotype file is the one attacker-controlled path into a numerical library, so the C extensions get static taint analysis. Runs in **manual build mode**, reproducing CI's two compile entry points (`jamma.lmm._compile_accel`, `jamma.jlinalg._compile_jlinalg`) so CodeQL traces the real compiler invocations.
- **SECURITY.md** — private vulnerability reporting (GitHub advisories + email) and an explicit threat model scoping reports to native input-parser memory safety.

## Why

Fills the two genuine gaps in an otherwise hardened posture. Existing coverage already handles workflow audit (zizmor/actionlint), runtime memory bugs (ASAN/UBSAN weekly), and dependency CVEs (OSV daily) — but nothing did **static** analysis of first-party C/Python source. CodeQL reaches every C path, not just the ones tests exercise.

## Notes

- Actions SHA-pinned with version comments per repo convention; `security-events: write` scoped to the analyze job only.
- All inputs to `run:` steps are fixed strings — no workflow-injection surface.
- Passes local actionlint, zizmor, markdownlint, lychee, typos.
- GitHub secret scanning / push protection / Dependabot already enabled (verified via API), so no settings changes needed.