### PR TITLE
chore: release 5.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.2] - 2026-06-03
+
 ### Added
 
 - **Pyrefly type-check gate**: CI lint job and a prek hook now run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jamma"
-version = "5.3.1"
+version = "5.3.2"
 description = "Highly-Accelerated Multi-method Mixed-Model Association for large-scale GWAS"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "jamma"
-version = "5.3.1"
+version = "5.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "bed-reader" },


### PR DESCRIPTION
Patch release. Finalizes the `[Unreleased]` changelog into **5.3.2** and bumps the version.

All changes this cycle are internal tooling + type-stub fixes — **no API or runtime behavior change**:
- Pyrefly type-check gate (CI + prek) with a committed baseline
- Corrected/completed `_jlinalg.pyi` and `_lmm_accel.pyi` stubs (ship in the wheel → better IDE/type-checking for consumers)
- `AccelImport` callable typing + `dict[str, Any]` sentinel (PEP-563 strings, no runtime effect)
- Gate hardening (pin `pyrefly==1.0.0`, `always_run` hook, 6 wrapper asserts, sentinel invariant test)

Baseline burn-down across the cycle: 487 → 374.

On merge, `gh release create v5.3.2` triggers `build-wheels.yml` → PyPI (trusted publishing).