### PR TITLE
feat(lmm): content-hash key for LOCO eigen cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **LOCO eigen-cache content hash**: per-chromosome eigen caches now carry a
+  `<prefix>.loco.cache_manifest.json` manifest keyed by a SHA-256 over the
+  inputs that determine the eigendecomposition (genotype `.bed`/`.bim`, MAF and
+  missingness thresholds, `-ksnps` restriction, and the analysed-sample mask).
+  On read, the key is recomputed and compared; a mismatch forces a full
+  recompute. New module `jamma.lmm.eigen_cache`.
+
+### Fixed
+
+- **Silent stale LOCO eigen cache**: a cached eigendecomposition was reused
+  whenever the per-chromosome files existed and matched on sample count, even
+  if the SNP filters, `-ksnps` set, or analysed-sample subset had changed
+  (same sample count, different missingness pattern). Those runs now detect the
+  changed inputs via the manifest and recompute. A cache written before the
+  manifest existed has no key and is recomputed once.
+
 ## [5.3.2] - 2026-06-03
 
 ### Added

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -87,6 +87,13 @@ or `-lmm` is required.
 | `-eigen` | flag | off | Write eigendecomposition files alongside kinship output |
 | `--eigen-dir` | path | — | Directory for LOCO per-chromosome eigen cache. With `-lmm -loco`, reads cached files to skip re-computation. With `-eigen`, writes them here. Only valid with `-loco`. |
 
+> **Cache validation.** The eigen cache is keyed by a content + parameter hash
+> over its determinants (the genotype files, MAF and missingness thresholds, any
+> `-ksnps` restriction, and the analysed-sample set), stored in
+> `<prefix>.loco.cache_manifest.json`. When any determinant changes the cache is
+> recomputed rather than silently reused. A cache written before the manifest
+> existed has no key and is recomputed once.
+
 ### Analysis modes
 
 | Flag | Type | Default | Description |

--- a/src/jamma/lmm/eigen_cache.py
+++ b/src/jamma/lmm/eigen_cache.py
@@ -1,0 +1,207 @@
+"""Content + parameter cache key for LOCO per-chromosome eigendecomposition.
+
+A manifest file written alongside eigen files records a SHA-256 digest of
+all inputs that determine the eigendecomposition (file identity, filter
+thresholds, sample mask, SNP restriction).  On the next run the digest is
+recomputed and compared; a mismatch forces a full recompute rather than
+silently reusing stale eigen files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+
+import numpy as np
+from loguru import logger
+
+EIGEN_CACHE_SCHEMA_VERSION: int = 1
+
+
+def _sha256_file(path: Path) -> str:
+    """Return hex SHA-256 of a file's bytes, read in 1 MiB chunks."""
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _build_components(
+    bed_path: Path,
+    *,
+    maf_threshold: float,
+    miss_threshold: float,
+    valid_mask: np.ndarray,
+    ksnps_indices: np.ndarray | None,
+) -> dict:
+    """Assemble the canonical dict of cache-key components.
+
+    Args:
+        bed_path: PLINK prefix (without extension); .bed and .bim are derived
+            by appending the appropriate suffix.
+        maf_threshold: Minimum MAF used for SNP filtering.
+        miss_threshold: Maximum missing rate used for SNP filtering.
+        valid_mask: Boolean array of shape (n_samples_total,); True = included.
+        ksnps_indices: Column indices for -ksnps restriction, or None.
+
+    Returns:
+        Dict ready for JSON serialisation as the key payload.
+    """
+    bed_file = Path(str(bed_path) + ".bed")
+    bim_file = Path(str(bed_path) + ".bim")
+
+    st = bed_file.stat()
+    bed_fingerprint = f"{bed_file.name}:{st.st_size}:{st.st_mtime_ns}"
+    bim_sha256 = _sha256_file(bim_file)
+
+    mask_bytes = np.ascontiguousarray(valid_mask, dtype=bool).tobytes()
+    valid_mask_sha256 = hashlib.sha256(mask_bytes).hexdigest()
+
+    if ksnps_indices is None:
+        ksnps_val: str = "none"
+    else:
+        arr = np.sort(np.unique(np.asarray(ksnps_indices, dtype=np.int64)))
+        ksnps_val = hashlib.sha256(arr.tobytes()).hexdigest()
+
+    return {
+        "schema_version": EIGEN_CACHE_SCHEMA_VERSION,
+        "bed_fingerprint": bed_fingerprint,
+        "bim_sha256": bim_sha256,
+        "maf_threshold": maf_threshold,
+        "miss_threshold": miss_threshold,
+        "valid_mask_sha256": valid_mask_sha256,
+        "ksnps": ksnps_val,
+    }
+
+
+def compute_eigen_cache_key(
+    bed_path: Path,
+    *,
+    maf_threshold: float,
+    miss_threshold: float,
+    valid_mask: np.ndarray,
+    ksnps_indices: np.ndarray | None = None,
+) -> str:
+    """Compute a SHA-256 cache key over all eigendecomposition determinants.
+
+    Args:
+        bed_path: PLINK prefix (without extension).
+        maf_threshold: Minimum MAF used for SNP filtering.
+        miss_threshold: Maximum missing rate used for SNP filtering.
+        valid_mask: Boolean array of shape (n_samples_total,); True = included.
+            Its length encodes total sample count, so different sample sets
+            (different length OR different True/False positions) yield distinct keys.
+        ksnps_indices: Column indices for -ksnps restriction, or None.
+            The SNP set is the determinant, so indices are sorted + de-duped
+            before hashing.
+
+    Returns:
+        Hex SHA-256 digest string.
+    """
+    components = _build_components(
+        bed_path,
+        maf_threshold=maf_threshold,
+        miss_threshold=miss_threshold,
+        valid_mask=valid_mask,
+        ksnps_indices=ksnps_indices,
+    )
+    canonical = json.dumps(components, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def eigen_cache_manifest_path(eigen_dir: Path, prefix: str) -> Path:
+    """Return the manifest path for a given eigen directory and prefix.
+
+    Args:
+        eigen_dir: Directory containing eigen files.
+        prefix: Filename prefix (e.g. "result").
+
+    Returns:
+        Path to the manifest JSON file.
+    """
+    return eigen_dir / f"{prefix}.loco.cache_manifest.json"
+
+
+def write_eigen_cache_manifest(
+    eigen_dir: Path,
+    prefix: str,
+    key: str,
+    *,
+    components: dict | None = None,
+) -> Path:
+    """Write a cache manifest JSON atomically.
+
+    Args:
+        eigen_dir: Directory containing eigen files.
+        prefix: Filename prefix (e.g. "result").
+        key: Hex SHA-256 cache key string.
+        components: Optional dict of key components for debuggability.
+
+    Returns:
+        Path to the written manifest file.
+    """
+    manifest = {
+        "schema_version": EIGEN_CACHE_SCHEMA_VERSION,
+        "cache_key": key,
+        "components": components or {},
+    }
+    target = eigen_cache_manifest_path(eigen_dir, prefix)
+    fd, tmp_name = tempfile.mkstemp(dir=eigen_dir, suffix=".json")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(manifest, fh)
+        tmp_path.replace(target)
+    except Exception:
+        with suppress(OSError):
+            tmp_path.unlink()
+        raise
+    return target
+
+
+def read_eigen_cache_manifest(eigen_dir: Path, prefix: str) -> dict | None:
+    """Read and parse the cache manifest.
+
+    Args:
+        eigen_dir: Directory containing eigen files.
+        prefix: Filename prefix.
+
+    Returns:
+        Parsed manifest dict, or None if absent or corrupt.
+    """
+    path = eigen_cache_manifest_path(eigen_dir, prefix)
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(f"Corrupt eigen cache manifest {path}: {exc}")
+        return None
+
+
+def eigen_cache_is_valid(
+    eigen_dir: Path, prefix: str, current_key: str
+) -> tuple[bool, str]:
+    """Check whether the on-disk eigen cache matches the current inputs.
+
+    Args:
+        eigen_dir: Directory containing eigen files.
+        prefix: Filename prefix.
+        current_key: Hex SHA-256 digest computed from the current inputs.
+
+    Returns:
+        Tuple of (is_valid, reason). reason is always a non-empty string.
+    """
+    manifest = read_eigen_cache_manifest(eigen_dir, prefix)
+    if manifest is None:
+        path = eigen_cache_manifest_path(eigen_dir, prefix)
+        return False, f"no valid cache manifest found at {path}"
+    if manifest.get("cache_key") == current_key:
+        return True, "cache key matches"
+    return False, "cache key mismatch: inputs changed since the eigen cache was written"

--- a/src/jamma/lmm/loco.py
+++ b/src/jamma/lmm/loco.py
@@ -41,6 +41,11 @@ from jamma.kinship import (
 )
 from jamma.lmm.compute_numpy import compute_lmm_chunk_numpy
 from jamma.lmm.eigen import eigendecompose_kinship
+from jamma.lmm.eigen_cache import (
+    compute_eigen_cache_key,
+    eigen_cache_is_valid,
+    write_eigen_cache_manifest,
+)
 from jamma.lmm.eigen_io import read_eigen_files, write_eigen_files
 from jamma.lmm.io import IncrementalAssocWriter
 from jamma.lmm.likelihood_numpy import batch_compute_uab_numpy
@@ -422,6 +427,22 @@ def run_lmm_loco(
                 eigen_dir, eigen_prefix, unique_chrs, legacy_text=legacy_text
             )
             if eigen_cache is not None:
+                current_key = compute_eigen_cache_key(
+                    bed_path,
+                    maf_threshold=maf_threshold,
+                    miss_threshold=miss_threshold,
+                    valid_mask=valid_mask,
+                    ksnps_indices=ksnps_indices,
+                )
+                ok, reason = eigen_cache_is_valid(eigen_dir, eigen_prefix, current_key)
+                if not ok:
+                    logger.warning(
+                        f"LOCO eigen cache in {eigen_dir} is stale or unverifiable "
+                        f"({reason}). Kinship and eigendecomposition will be "
+                        f"recomputed."
+                    )
+                    eigen_cache = None
+            if eigen_cache is not None:
                 logger.info(
                     f"Found complete LOCO eigen cache in {eigen_dir} "
                     f"({len(eigen_cache)} chromosomes). "
@@ -625,6 +646,30 @@ def run_lmm_loco(
 
             del eigenvalues_np, U
             gc.collect()
+
+        if write_eigen and eigen_cache is None:
+            key = compute_eigen_cache_key(
+                bed_path,
+                maf_threshold=maf_threshold,
+                miss_threshold=miss_threshold,
+                valid_mask=valid_mask,
+                ksnps_indices=ksnps_indices,
+            )
+            write_eigen_cache_manifest(
+                eigen_dir,  # type: ignore[arg-type]  # guaranteed non-None when write_eigen
+                eigen_prefix,
+                key,
+                components={
+                    "maf_threshold": maf_threshold,
+                    "miss_threshold": miss_threshold,
+                    "n_samples_total": int(valid_mask.shape[0]),
+                    "n_valid": int(np.sum(valid_mask)),
+                    "ksnps_indices": "none"
+                    if ksnps_indices is None
+                    else len(ksnps_indices),
+                },
+            )
+            logger.info(f"Wrote LOCO eigen cache manifest to {eigen_dir}")
 
         if first_chr_pve is None:
             logger.warning(

--- a/tests/test_loco_eigen_cache.py
+++ b/tests/test_loco_eigen_cache.py
@@ -561,3 +561,263 @@ class TestLocoLegacyText:
             assert (tmp_path / f"result.loco.cXX.chr{ch}.txt").exists(), (
                 f"Missing .txt kinship for chr {ch}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Content + parameter cache-key tests (manifest-based stale-cache detection)
+# ---------------------------------------------------------------------------
+
+
+def _write_dummy_plink(
+    prefix: Path,
+    *,
+    bed_size: int = 64,
+    bim_lines: list[str] | None = None,
+    bed_fill: int = 0,
+) -> None:
+    """Write minimal .bed/.bim files at ``prefix`` for cache-key unit tests.
+
+    The cache-key function only stats .bed (name + size + mtime) and hashes
+    .bim content, so these need not be valid PLINK binaries.
+    """
+    if bim_lines is None:
+        bim_lines = [
+            "1\trs1\t0\t100\tA\tG",
+            "1\trs2\t0\t200\tC\tT",
+            "2\trs3\t0\t300\tA\tT",
+        ]
+    prefix.with_suffix(".bed").write_bytes(bytes([bed_fill]) * bed_size)
+    prefix.with_suffix(".bim").write_text("\n".join(bim_lines) + "\n")
+
+
+def _compute_key(
+    prefix: Path,
+    *,
+    maf_threshold: float = 0.01,
+    miss_threshold: float = 0.05,
+    valid_mask: np.ndarray | None = None,
+    ksnps_indices: np.ndarray | None = None,
+) -> str:
+    """Call compute_eigen_cache_key with per-test overrides over fixed defaults.
+
+    Explicit keyword forwarding (not dict-unpacking) keeps the call type-clean.
+    """
+    from jamma.lmm.eigen_cache import compute_eigen_cache_key
+
+    if valid_mask is None:
+        valid_mask = np.ones(20, dtype=bool)
+    return compute_eigen_cache_key(
+        prefix,
+        maf_threshold=maf_threshold,
+        miss_threshold=miss_threshold,
+        valid_mask=valid_mask,
+        ksnps_indices=ksnps_indices,
+    )
+
+
+class TestEigenCacheKey:
+    """compute_eigen_cache_key changes iff a real eigen-pair determinant changes."""
+
+    def test_key_is_stable_for_identical_inputs(self, tmp_path: Path) -> None:
+        prefix = tmp_path / "data"
+        _write_dummy_plink(prefix)
+        k1 = _compute_key(prefix)
+        k2 = _compute_key(prefix)
+        assert isinstance(k1, str)
+        assert len(k1) > 0
+        assert k1 == k2
+
+    def test_key_changes_when_maf_threshold_changes(self, tmp_path: Path) -> None:
+        prefix = tmp_path / "data"
+        _write_dummy_plink(prefix)
+        assert _compute_key(prefix) != _compute_key(prefix, maf_threshold=0.05)
+
+    def test_key_changes_when_miss_threshold_changes(self, tmp_path: Path) -> None:
+        prefix = tmp_path / "data"
+        _write_dummy_plink(prefix)
+        assert _compute_key(prefix) != _compute_key(prefix, miss_threshold=0.10)
+
+    def test_key_changes_when_valid_mask_positions_change(self, tmp_path: Path) -> None:
+        """Same valid COUNT, different valid POSITIONS -> different key.
+
+        This is the silent-stale hole the manifest closes: two phenotypes with
+        the same number of non-missing samples but a different missingness
+        pattern select a different sample subset, hence a different K.
+        """
+        prefix = tmp_path / "data"
+        _write_dummy_plink(prefix)
+        m1 = np.ones(20, dtype=bool)
+        m1[0] = False
+        m2 = np.ones(20, dtype=bool)
+        m2[1] = False
+        assert int(m1.sum()) == int(m2.sum())  # same count
+        k1 = _compute_key(prefix, valid_mask=m1)
+        k2 = _compute_key(prefix, valid_mask=m2)
+        assert k1 != k2
+
+    def test_key_changes_when_valid_mask_length_changes(self, tmp_path: Path) -> None:
+        """Different total sample count (.fam size) -> different key."""
+        prefix = tmp_path / "data"
+        _write_dummy_plink(prefix)
+        k1 = _compute_key(prefix, valid_mask=np.ones(20, dtype=bool))
+        k2 = _compute_key(prefix, valid_mask=np.ones(19, dtype=bool))
+        assert k1 != k2
+
+    def test_key_changes_when_bim_content_changes(self, tmp_path: Path) -> None:
+        """Re-annotating a SNP's chromosome changes the LOCO partition -> key."""
+        prefix = tmp_path / "data"
+        _write_dummy_plink(prefix)
+        k1 = _compute_key(prefix)
+        _write_dummy_plink(
+            prefix,
+            bim_lines=[
+                "1\trs1\t0\t100\tA\tG",
+                "1\trs2\t0\t200\tC\tT",
+                "3\trs3\t0\t300\tA\tT",  # chr 2 -> 3
+            ],
+        )
+        assert k1 != _compute_key(prefix)
+
+    def test_key_changes_when_bed_content_changes(self, tmp_path: Path) -> None:
+        """A different .bed (here: different size) -> different key."""
+        prefix = tmp_path / "data"
+        _write_dummy_plink(prefix, bed_size=64)
+        k1 = _compute_key(prefix)
+        _write_dummy_plink(prefix, bed_size=128)
+        assert k1 != _compute_key(prefix)
+
+    def test_key_changes_when_ksnps_changes(self, tmp_path: Path) -> None:
+        """Different kinship-SNP restriction -> different key; None differs too."""
+        prefix = tmp_path / "data"
+        _write_dummy_plink(prefix)
+        k_none = _compute_key(prefix)
+        k_a = _compute_key(prefix, ksnps_indices=np.array([0, 1]))
+        k_b = _compute_key(prefix, ksnps_indices=np.array([0, 2]))
+        assert k_none != k_a
+        assert k_none != k_b
+        assert k_a != k_b
+
+
+class TestEigenCacheManifest:
+    """Manifest read/write/validate behavior for stale-cache detection."""
+
+    def test_absent_manifest_is_invalid(self, tmp_path: Path) -> None:
+        from jamma.lmm.eigen_cache import eigen_cache_is_valid
+
+        ok, reason = eigen_cache_is_valid(tmp_path, "result", "somekey")
+        assert ok is False
+        assert "manifest" in reason.lower()
+
+    def test_matching_key_is_valid(self, tmp_path: Path) -> None:
+        from jamma.lmm.eigen_cache import (
+            eigen_cache_is_valid,
+            write_eigen_cache_manifest,
+        )
+
+        write_eigen_cache_manifest(tmp_path, "result", "KEY123")
+        ok, _reason = eigen_cache_is_valid(tmp_path, "result", "KEY123")
+        assert ok is True
+
+    def test_mismatched_key_is_invalid(self, tmp_path: Path) -> None:
+        from jamma.lmm.eigen_cache import (
+            eigen_cache_is_valid,
+            write_eigen_cache_manifest,
+        )
+
+        write_eigen_cache_manifest(tmp_path, "result", "KEY123")
+        ok, reason = eigen_cache_is_valid(tmp_path, "result", "DIFFERENT")
+        assert ok is False
+        assert reason
+
+    def test_manifest_roundtrip(self, tmp_path: Path) -> None:
+        from jamma.lmm.eigen_cache import (
+            read_eigen_cache_manifest,
+            write_eigen_cache_manifest,
+        )
+
+        path = write_eigen_cache_manifest(tmp_path, "result", "KEY123")
+        assert path.exists()
+        manifest = read_eigen_cache_manifest(tmp_path, "result")
+        assert manifest is not None
+        assert manifest["cache_key"] == "KEY123"
+
+    def test_corrupt_manifest_is_invalid(self, tmp_path: Path) -> None:
+        from jamma.lmm.eigen_cache import (
+            eigen_cache_is_valid,
+            eigen_cache_manifest_path,
+        )
+
+        eigen_cache_manifest_path(tmp_path, "result").write_text("{ not json")
+        ok, reason = eigen_cache_is_valid(tmp_path, "result", "KEY")
+        assert ok is False
+        assert reason
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not _mouse_hs1940_exists(), reason="mouse_hs1940 fixture not available"
+)
+class TestLocoEigenCacheStaleDetection:
+    """End-to-end: a cache whose inputs changed must NOT be silently reused."""
+
+    def test_changed_filter_invalidates_cache(self, tmp_path: Path) -> None:
+        """Cache written at maf=0.01, then read with maf=0.05, must recompute.
+
+        Proven by equality to a from-scratch maf=0.05 run: if the stale maf=0.01
+        eigen cache were silently reused, results would differ.
+        """
+        from jamma.lmm.loco import run_lmm_loco
+        from jamma.validation.compare import load_gemma_assoc
+        from tests.conftest import load_phenotypes_from_fam
+
+        fam_path = MOUSE_HS1940_BFILE.with_suffix(".fam")
+        phenotypes = load_phenotypes_from_fam(fam_path)
+        eigen_dir = tmp_path / "eigen_cache"
+        eigen_dir.mkdir()
+
+        common = {
+            "bed_path": MOUSE_HS1940_BFILE,
+            "phenotypes": phenotypes,
+            "lmm_mode": 1,
+            "check_memory": False,
+            "show_progress": False,
+            "miss_threshold": 0.05,
+        }
+
+        out_fresh = tmp_path / "fresh.assoc.txt"
+        run_lmm_loco(**common, maf_threshold=0.05, output_path=out_fresh)
+
+        run_lmm_loco(
+            **common,
+            maf_threshold=0.01,
+            output_path=tmp_path / "populate.assoc.txt",
+            write_eigen=True,
+            eigen_dir=eigen_dir,
+        )
+
+        out_cached = tmp_path / "cached.assoc.txt"
+        run_lmm_loco(
+            **common,
+            maf_threshold=0.05,
+            output_path=out_cached,
+            eigen_dir=eigen_dir,
+        )
+
+        fresh = {r.rs: r for r in load_gemma_assoc(out_fresh)}
+        cached = {r.rs: r for r in load_gemma_assoc(out_cached)}
+        assert fresh
+        assert cached
+        common_rs = set(fresh) & set(cached)
+        assert common_rs
+        for rs in common_rs:
+            b_fresh = fresh[rs].beta
+            b_cached = cached[rs].beta
+            assert b_fresh is not None
+            assert b_cached is not None
+            np.testing.assert_allclose(
+                b_cached,
+                b_fresh,
+                rtol=1e-8,
+                atol=1e-14,
+                err_msg=f"beta {rs}: stale maf=0.01 cache silently reused",
+            )


### PR DESCRIPTION
Per-chromosome LOCO eigen caches were reused whenever the eigen files
existed and matched on sample count, even if the inputs that determine
the eigendecomposition had changed. The risky case is same sample count
but a different analysed-sample subset (a phenotype with the same number
of non-missing values but a different missingness pattern) or a changed
SNP filter / `-ksnps` set: the dimension check passes, so the stale eigen
pairs were silently reused.

This adds a manifest, `<prefix>.loco.cache_manifest.json`, keyed by a
SHA-256 over the eigendecomposition determinants:

- `.bed` fingerprint (name, size, mtime) and full `.bim` content hash
- MAF and missingness thresholds
- `-ksnps` restriction (sorted, de-duped)
- the analysed-sample mask (its length also encodes total sample count)

On read the key is recomputed and compared; a mismatch (or an absent
manifest, e.g. a cache written before this change) forces a full
recompute instead of reuse. New module `jamma.lmm.eigen_cache`, wired
into `run_lmm_loco`. The manifest is written once after all chromosomes
complete, so a crash mid-run leaves no manifest and the next run recomputes.

The determinant set was derived adversarially: covariate values, HWE, and
weight files were confirmed NOT to affect the eigen pairs (covariates
enter only via the sample mask), so they are excluded; centering is a
fixed code constant folded into the schema version.

Verification: 13 new unit tests (key stability + per-determinant
sensitivity + manifest validate); a slow end-to-end test on mouse_hs1940
proving a maf=0.01 cache is recomputed (not reused) when read at maf=0.05;
the existing identical-results round-trip regression still passes; 101
adjacent LOCO/eigen tests green; pyrefly gate 0 new errors.