### PR TITLE
fix(lmm): honest LOCO eigen-cache manifest — persist real components, invalidate before rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **LOCO eigen-cache content hash**: per-chromosome eigen caches now carry a
+- **LOCO eigen-cache manifest**: per-chromosome eigen caches now carry a
   `<prefix>.loco.cache_manifest.json` manifest keyed by a SHA-256 over the
-  inputs that determine the eigendecomposition (genotype `.bed`/`.bim`, MAF and
-  missingness thresholds, `-ksnps` restriction, and the analysed-sample mask).
-  On read, the key is recomputed and compared; a mismatch forces a full
-  recompute. New module `jamma.lmm.eigen_cache`.
+  inputs that determine the eigendecomposition: the `.bim` is content-hashed,
+  the `.bed` is fingerprinted by size + modification time (not content-hashed,
+  to avoid re-reading large genotype files), plus the MAF and missingness
+  thresholds, `-ksnps` restriction, and the analysed-sample mask. On read, the
+  key is recomputed and compared; a mismatch forces a full recompute. New
+  module `jamma.lmm.eigen_cache`.
 
 ### Fixed
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -87,12 +87,16 @@ or `-lmm` is required.
 | `-eigen` | flag | off | Write eigendecomposition files alongside kinship output |
 | `--eigen-dir` | path | — | Directory for LOCO per-chromosome eigen cache. With `-lmm -loco`, reads cached files to skip re-computation. With `-eigen`, writes them here. Only valid with `-loco`. |
 
-> **Cache validation.** The eigen cache is keyed by a content + parameter hash
-> over its determinants (the genotype files, MAF and missingness thresholds, any
-> `-ksnps` restriction, and the analysed-sample set), stored in
-> `<prefix>.loco.cache_manifest.json`. When any determinant changes the cache is
-> recomputed rather than silently reused. A cache written before the manifest
-> existed has no key and is recomputed once.
+> **Cache validation.** The eigen cache is keyed by a SHA-256 over its
+> determinants: the `.bim` is content-hashed, the `.bed` is fingerprinted by
+> size + modification time, plus the MAF and missingness thresholds, any
+> `-ksnps` restriction, and the analysed-sample set, stored in
+> `<prefix>.loco.cache_manifest.json`. The `.bed` is fingerprinted rather than
+> fully hashed to avoid re-reading large genotype files every run; regenerating
+> genotypes changes the `.bed` size or timestamp and invalidates the cache.
+> When any determinant changes the cache is recomputed rather than silently
+> reused. A cache written before the manifest existed has no key and is
+> recomputed once.
 
 ### Analysis modes
 

--- a/src/jamma/lmm/eigen_cache.py
+++ b/src/jamma/lmm/eigen_cache.py
@@ -130,6 +130,18 @@ def eigen_cache_manifest_path(eigen_dir: Path, prefix: str) -> Path:
     return eigen_dir / f"{prefix}.loco.cache_manifest.json"
 
 
+def invalidate_eigen_cache_manifest(eigen_dir: Path, prefix: str) -> None:
+    """Remove the cache manifest if present; no-op if absent.
+
+    Called before a write_eigen rewrite so a stale manifest cannot validate a
+    half-rewritten eigen cache: the fresh manifest is written only after all
+    per-chromosome eigen files succeed, so an interrupted rewrite leaves no
+    manifest and the next read recomputes.
+    """
+    with suppress(FileNotFoundError):
+        eigen_cache_manifest_path(eigen_dir, prefix).unlink()
+
+
 def write_eigen_cache_manifest(
     eigen_dir: Path,
     prefix: str,

--- a/src/jamma/lmm/eigen_cache.py
+++ b/src/jamma/lmm/eigen_cache.py
@@ -86,7 +86,7 @@ def compute_eigen_cache_key(
     miss_threshold: float,
     valid_mask: np.ndarray,
     ksnps_indices: np.ndarray | None = None,
-) -> str:
+) -> tuple[str, dict]:
     """Compute a SHA-256 cache key over all eigendecomposition determinants.
 
     Args:
@@ -101,7 +101,9 @@ def compute_eigen_cache_key(
             before hashing.
 
     Returns:
-        Hex SHA-256 digest string.
+        Tuple of (key, components). key is the hex SHA-256 digest. components is
+        the exact canonical payload that was hashed, returned so the caller can
+        persist it in the manifest and diff it against a future mismatch.
     """
     components = _build_components(
         bed_path,
@@ -111,7 +113,8 @@ def compute_eigen_cache_key(
         ksnps_indices=ksnps_indices,
     )
     canonical = json.dumps(components, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    key = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return key, components
 
 
 def eigen_cache_manifest_path(eigen_dir: Path, prefix: str) -> Path:
@@ -132,7 +135,7 @@ def write_eigen_cache_manifest(
     prefix: str,
     key: str,
     *,
-    components: dict | None = None,
+    components: dict,
 ) -> Path:
     """Write a cache manifest JSON atomically.
 
@@ -140,7 +143,8 @@ def write_eigen_cache_manifest(
         eigen_dir: Directory containing eigen files.
         prefix: Filename prefix (e.g. "result").
         key: Hex SHA-256 cache key string.
-        components: Optional dict of key components for debuggability.
+        components: Dict of key components (the payload that was hashed) for
+            debuggability.
 
     Returns:
         Path to the written manifest file.
@@ -148,7 +152,7 @@ def write_eigen_cache_manifest(
     manifest = {
         "schema_version": EIGEN_CACHE_SCHEMA_VERSION,
         "cache_key": key,
-        "components": components or {},
+        "components": components,
     }
     target = eigen_cache_manifest_path(eigen_dir, prefix)
     fd, tmp_name = tempfile.mkstemp(dir=eigen_dir, suffix=".json")

--- a/src/jamma/lmm/loco.py
+++ b/src/jamma/lmm/loco.py
@@ -44,6 +44,7 @@ from jamma.lmm.eigen import eigendecompose_kinship
 from jamma.lmm.eigen_cache import (
     compute_eigen_cache_key,
     eigen_cache_is_valid,
+    invalidate_eigen_cache_manifest,
     write_eigen_cache_manifest,
 )
 from jamma.lmm.eigen_io import read_eigen_files, write_eigen_files
@@ -504,12 +505,19 @@ def run_lmm_loco(
             # (eigen_dir is guaranteed non-None when write_eigen is True
             # by the early guard at the top of this function.)
             if write_eigen:
+                # write_eigen guarantees eigen_dir (entry guard at top of function).
+                assert eigen_dir is not None
                 try:
                     eigen_dir.mkdir(parents=True, exist_ok=True)
                 except OSError as e:
                     raise OSError(
                         f"Cannot create eigen cache directory {eigen_dir}: {e}"
                     ) from e
+                # Invalidate any stale manifest before rewriting eigen files. The fresh
+                # manifest is written only after the loop completes, so an interrupted
+                # rewrite leaves no manifest and the next read recomputes rather than
+                # trusting a half-rewritten cache.
+                invalidate_eigen_cache_manifest(eigen_dir, eigen_prefix)
 
         first_chr_pve: float | None = None
         first_chr_pve_se: float | None = None

--- a/src/jamma/lmm/loco.py
+++ b/src/jamma/lmm/loco.py
@@ -418,6 +418,22 @@ def run_lmm_loco(
         else:
             snps_global_mask = None
 
+        # Content + parameter key over every determinant of the eigendecomposition
+        # (genotype files, filter thresholds, -ksnps set, analysed-sample mask).
+        # Computed once and reused on both the read (validate) and write (persist)
+        # paths below. Those paths are mutually exclusive at runtime but key off
+        # the same inputs.
+        eigen_cache_key: str | None = None
+        eigen_cache_components: dict | None = None
+        if eigen_dir is not None:
+            eigen_cache_key, eigen_cache_components = compute_eigen_cache_key(
+                bed_path,
+                maf_threshold=maf_threshold,
+                miss_threshold=miss_threshold,
+                valid_mask=valid_mask,
+                ksnps_indices=ksnps_indices,
+            )
+
         # Check for cached eigen files before computing kinship.
         # When write_eigen is True the user explicitly asked to
         # (re)generate files, so skip the cache and recompute.
@@ -427,14 +443,11 @@ def run_lmm_loco(
                 eigen_dir, eigen_prefix, unique_chrs, legacy_text=legacy_text
             )
             if eigen_cache is not None:
-                current_key = compute_eigen_cache_key(
-                    bed_path,
-                    maf_threshold=maf_threshold,
-                    miss_threshold=miss_threshold,
-                    valid_mask=valid_mask,
-                    ksnps_indices=ksnps_indices,
+                # eigen_cache_key is set whenever eigen_dir is not None.
+                assert eigen_cache_key is not None
+                ok, reason = eigen_cache_is_valid(
+                    eigen_dir, eigen_prefix, eigen_cache_key
                 )
-                ok, reason = eigen_cache_is_valid(eigen_dir, eigen_prefix, current_key)
                 if not ok:
                     logger.warning(
                         f"LOCO eigen cache in {eigen_dir} is stale or unverifiable "
@@ -648,26 +661,16 @@ def run_lmm_loco(
             gc.collect()
 
         if write_eigen and eigen_cache is None:
-            key = compute_eigen_cache_key(
-                bed_path,
-                maf_threshold=maf_threshold,
-                miss_threshold=miss_threshold,
-                valid_mask=valid_mask,
-                ksnps_indices=ksnps_indices,
-            )
+            # write_eigen guarantees eigen_dir (entry guard), and the key block
+            # above ran because eigen_dir is not None, so all three are set.
+            assert eigen_dir is not None
+            assert eigen_cache_key is not None
+            assert eigen_cache_components is not None
             write_eigen_cache_manifest(
-                eigen_dir,  # type: ignore[arg-type]  # guaranteed non-None when write_eigen
+                eigen_dir,
                 eigen_prefix,
-                key,
-                components={
-                    "maf_threshold": maf_threshold,
-                    "miss_threshold": miss_threshold,
-                    "n_samples_total": int(valid_mask.shape[0]),
-                    "n_valid": int(np.sum(valid_mask)),
-                    "ksnps_indices": "none"
-                    if ksnps_indices is None
-                    else len(ksnps_indices),
-                },
+                eigen_cache_key,
+                components=eigen_cache_components,
             )
             logger.info(f"Wrote LOCO eigen cache manifest to {eigen_dir}")
 

--- a/tests/test_loco_eigen_cache.py
+++ b/tests/test_loco_eigen_cache.py
@@ -778,6 +778,25 @@ class TestEigenCacheManifest:
         assert ok is False
         assert reason
 
+    def test_invalidate_removes_present_manifest_and_no_ops_when_absent(
+        self, tmp_path: Path
+    ) -> None:
+        from jamma.lmm.eigen_cache import (
+            eigen_cache_manifest_path,
+            invalidate_eigen_cache_manifest,
+            write_eigen_cache_manifest,
+        )
+
+        write_eigen_cache_manifest(tmp_path, "result", "KEY", components={})
+        manifest = eigen_cache_manifest_path(tmp_path, "result")
+        assert manifest.exists()
+
+        invalidate_eigen_cache_manifest(tmp_path, "result")
+        assert manifest.exists() is False
+
+        invalidate_eigen_cache_manifest(tmp_path, "result")
+        assert manifest.exists() is False
+
 
 @pytest.mark.slow
 @pytest.mark.skipif(
@@ -847,3 +866,80 @@ class TestLocoEigenCacheStaleDetection:
                 atol=1e-14,
                 err_msg=f"beta {rs}: stale maf=0.01 cache silently reused",
             )
+
+    def test_interrupted_rewrite_leaves_no_stale_manifest(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An interrupted write_eigen rewrite must leave no manifest.
+
+        Run 1 writes a complete maf=0.01 cache + manifest. Run 2 rewrites with
+        maf=0.05 but is interrupted on the second chromosome. The maf=0.01
+        manifest must already be gone (invalidated before the loop), so a later
+        read with the maf=0.01 inputs cannot validate the half-rewritten cache.
+        """
+        import jamma.lmm.loco as loco_mod
+        from jamma.lmm.eigen_cache import eigen_cache_manifest_path
+        from jamma.lmm.loco import run_lmm_loco
+        from tests.conftest import load_phenotypes_from_fam
+
+        fam_path = MOUSE_HS1940_BFILE.with_suffix(".fam")
+        phenotypes = load_phenotypes_from_fam(fam_path)
+        eigen_dir = tmp_path / "eigen_cache"
+        eigen_dir.mkdir()
+
+        common = {
+            "bed_path": MOUSE_HS1940_BFILE,
+            "phenotypes": phenotypes,
+            "lmm_mode": 1,
+            "check_memory": False,
+            "show_progress": False,
+            "miss_threshold": 0.05,
+        }
+
+        run_lmm_loco(
+            **common,
+            maf_threshold=0.01,
+            output_path=tmp_path / "populate.assoc.txt",
+            write_eigen=True,
+            eigen_dir=eigen_dir,
+        )
+        manifest = eigen_cache_manifest_path(eigen_dir, "result")
+        assert manifest.exists()
+
+        real_write_eigen_files = loco_mod.write_eigen_files
+        calls = {"n": 0}
+
+        def interrupting_write_eigen_files(
+            eigenvalues: np.ndarray,
+            eigenvectors: np.ndarray,
+            output_dir: Path,
+            prefix: str = "result",
+            *,
+            legacy_text: bool = False,
+        ) -> tuple[Path, Path]:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return real_write_eigen_files(
+                    eigenvalues,
+                    eigenvectors,
+                    output_dir,
+                    prefix=prefix,
+                    legacy_text=legacy_text,
+                )
+            raise RuntimeError("simulated interruption")
+
+        monkeypatch.setattr(
+            loco_mod, "write_eigen_files", interrupting_write_eigen_files
+        )
+
+        with pytest.raises(RuntimeError, match="simulated interruption"):
+            run_lmm_loco(
+                **common,
+                maf_threshold=0.05,
+                output_path=tmp_path / "interrupted.assoc.txt",
+                write_eigen=True,
+                eigen_dir=eigen_dir,
+            )
+
+        assert calls["n"] >= 2, "interruption did not run the real writer first"
+        assert manifest.exists() is False

--- a/tests/test_loco_eigen_cache.py
+++ b/tests/test_loco_eigen_cache.py
@@ -606,13 +606,14 @@ def _compute_key(
 
     if valid_mask is None:
         valid_mask = np.ones(20, dtype=bool)
-    return compute_eigen_cache_key(
+    key, _components = compute_eigen_cache_key(
         prefix,
         maf_threshold=maf_threshold,
         miss_threshold=miss_threshold,
         valid_mask=valid_mask,
         ksnps_indices=ksnps_indices,
     )
+    return key
 
 
 class TestEigenCacheKey:
@@ -697,6 +698,28 @@ class TestEigenCacheKey:
         assert k_none != k_b
         assert k_a != k_b
 
+    def test_returns_canonical_components(self, tmp_path: Path) -> None:
+        """Second return value is the exact hashed payload (for the manifest)."""
+        import hashlib
+        import json
+
+        from jamma.lmm.eigen_cache import compute_eigen_cache_key
+
+        prefix = tmp_path / "data"
+        _write_dummy_plink(prefix)
+        key, components = compute_eigen_cache_key(
+            prefix,
+            maf_threshold=0.01,
+            miss_threshold=0.05,
+            valid_mask=np.ones(20, dtype=bool),
+        )
+        assert isinstance(components, dict)
+        hashed_keys = {"bed_fingerprint", "bim_sha256", "valid_mask_sha256"}
+        assert hashed_keys <= components.keys()
+        canonical = json.dumps(components, sort_keys=True, separators=(",", ":"))
+        expected = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        assert key == expected
+
 
 class TestEigenCacheManifest:
     """Manifest read/write/validate behavior for stale-cache detection."""
@@ -714,7 +737,7 @@ class TestEigenCacheManifest:
             write_eigen_cache_manifest,
         )
 
-        write_eigen_cache_manifest(tmp_path, "result", "KEY123")
+        write_eigen_cache_manifest(tmp_path, "result", "KEY123", components={})
         ok, _reason = eigen_cache_is_valid(tmp_path, "result", "KEY123")
         assert ok is True
 
@@ -724,7 +747,7 @@ class TestEigenCacheManifest:
             write_eigen_cache_manifest,
         )
 
-        write_eigen_cache_manifest(tmp_path, "result", "KEY123")
+        write_eigen_cache_manifest(tmp_path, "result", "KEY123", components={})
         ok, reason = eigen_cache_is_valid(tmp_path, "result", "DIFFERENT")
         assert ok is False
         assert reason
@@ -735,11 +758,14 @@ class TestEigenCacheManifest:
             write_eigen_cache_manifest,
         )
 
-        path = write_eigen_cache_manifest(tmp_path, "result", "KEY123")
+        path = write_eigen_cache_manifest(
+            tmp_path, "result", "KEY123", components={"maf_threshold": 0.01}
+        )
         assert path.exists()
         manifest = read_eigen_cache_manifest(tmp_path, "result")
         assert manifest is not None
         assert manifest["cache_key"] == "KEY123"
+        assert manifest["components"] == {"maf_threshold": 0.01}
 
     def test_corrupt_manifest_is_invalid(self, tmp_path: Path) -> None:
         from jamma.lmm.eigen_cache import (


### PR DESCRIPTION
Follow-ups from a code-quality review of #49 (LOCO eigen-cache content-hash key).

## Changes

**1. Persist the real hashed components in the manifest (single source of truth).**
`compute_eigen_cache_key` built the canonical determinant dict (`bed_fingerprint`, `bim_sha256`, `valid_mask_sha256`, thresholds, ksnps) only to discard it, while `loco.py` hand-rolled a *separate* summary dict to store in the manifest. That made the manifest's stated "debuggability" hollow (it omitted the actual hashed inputs) and created two drift-prone lists of "what determines the key". Now `compute_eigen_cache_key` returns `(key, components)`, the manifest stores the exact hashed payload, and the duplicate inline key computation at the read/write sites collapses to one. `write_eigen_cache_manifest`'s `components` is now required (dropped the `dict | None = None` + `or {}`). The `# type: ignore[arg-type]` on `eigen_dir` is replaced by narrowing asserts.

**2. Correct the ".bed content-hash" overclaim (docs).**
The `.bed` is keyed by size + mtime (a fingerprint), only the `.bim` is content-hashed. CHANGELOG and `docs/CONFIGURATION.md` now state this accurately, with the rationale (fingerprinting avoids re-reading large genotype files; regeneration still moves size/mtime and invalidates the cache). Behavior unchanged — full `.bed` hashing would defeat the cache on the large genotype files LOCO eigen caching exists to serve.

**3. Invalidate the stale manifest before a `write_eigen` rewrite (robustness).**
The fresh manifest was written only after the per-chromosome loop, but the old one was never removed first. An interrupted rewrite with changed inputs could leave an old manifest + mixed old/new eigen files that still validate for the old inputs (silent corrupt reuse). Now the manifest is deleted before the rewrite loop and rewritten only on success (invalidate-before-mutate, commit-after); an interrupted rewrite leaves no manifest, so the next read recomputes. A negative-control test confirms it fails without the fix.

## Verification
- `ruff check` / `ruff format --check`: clean
- `pyrefly check --baseline pyrefly-baseline.json`: 0 errors (no new findings; the prior `arg-type` ignore removed)
- `pytest tests/test_loco_eigen_cache.py -m "slow or not slow"`: 35 passed (incl. all slow end-to-end tests against mouse_hs1940)