### PR TITLE
chore: release 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.0] - 2026-06-10
+
 ### Added
 
 - **LOCO eigen-cache manifest**: per-chromosome eigen caches now carry a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jamma"
-version = "5.3.2"
+version = "5.4.0"
 description = "Highly-Accelerated Multi-method Mixed-Model Association for large-scale GWAS"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "jamma"
-version = "5.3.2"
+version = "5.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "bed-reader" },


### PR DESCRIPTION
Release 5.4.0.

## Highlights (CHANGELOG `[5.4.0]`)
- **Added** — LOCO eigen-cache manifest (`<prefix>.loco.cache_manifest.json`): content+parameter SHA-256 over the eigendecomposition determinants (`.bim` content-hashed, `.bed` fingerprinted by size+mtime, plus MAF/missingness thresholds, `-ksnps`, analysed-sample mask). A mismatch forces recompute (#49, refined in #50).
- **Fixed** — silent stale LOCO eigen cache reuse when filters/`-ksnps`/sample subset changed at the same sample count (#49).

Also folds in dependency bumps merged separately: numpy 2.4.5→2.4.6, hatchling 1.29.0→1.30.1 (#48), astral-sh/setup-uv 8.1.0→8.2.0 (#46).

Version bumped in `pyproject.toml` + `uv.lock`. Tagging `v5.4.0` after merge triggers `build-wheels.yml` to publish to PyPI.