### PR TITLE
fix(lmm): eigen-cache review follow-ups — diagnostics, schema gate, durability, types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **LOCO eigen-cache invalidation diagnostics**: `eigen_cache_is_valid` now
+  reports a malformed manifest (parses but has no `cache_key`, e.g. an
+  old-schema or truncated file) distinctly from a real input change, and
+  enforces the manifest `schema_version` explicitly before the key compare
+  instead of relying only on its presence in the hashed payload. A
+  schema-version bump now invalidates all prior caches with a clear log reason.
+  The manifest is `fsync`'d before its atomic rename so a crash cannot leave a
+  parseable-but-garbage manifest, and corrupt-vs-unreadable manifests log
+  distinct warnings. Manifest and components payloads are now typed via
+  `TypedDict` (`EigenCacheComponents`, `EigenCacheManifest`).
+
 ## [5.4.0] - 2026-06-10
 
 ### Added
@@ -27,7 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if the SNP filters, `-ksnps` set, or analysed-sample subset had changed
   (same sample count, different missingness pattern). Those runs now detect the
   changed inputs via the manifest and recompute. A cache written before the
-  manifest existed has no key and is recomputed once.
+  manifest existed has no key; it is rejected and recomputed on every read run
+  until regenerated with `-eigen`, which writes a manifest.
 
 ## [5.3.2] - 2026-06-03
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -90,13 +90,15 @@ or `-lmm` is required.
 > **Cache validation.** The eigen cache is keyed by a SHA-256 over its
 > determinants: the `.bim` is content-hashed, the `.bed` is fingerprinted by
 > size + modification time, plus the MAF and missingness thresholds, any
-> `-ksnps` restriction, and the analysed-sample set, stored in
+> `-ksnps` restriction, the analysed-sample set, and the manifest
+> `schema_version` (bumping it invalidates all prior caches), stored in
 > `<prefix>.loco.cache_manifest.json`. The `.bed` is fingerprinted rather than
 > fully hashed to avoid re-reading large genotype files every run; regenerating
 > genotypes changes the `.bed` size or timestamp and invalidates the cache.
 > When any determinant changes the cache is recomputed rather than silently
-> reused. A cache written before the manifest existed has no key and is
-> recomputed once.
+> reused. A cache written before the manifest existed has no key; it is
+> rejected and recomputed on every read run until regenerated with `-eigen`,
+> which writes a manifest.
 
 ### Analysis modes
 

--- a/src/jamma/lmm/eigen_cache.py
+++ b/src/jamma/lmm/eigen_cache.py
@@ -4,7 +4,9 @@ A manifest file written alongside eigen files records a SHA-256 digest of
 all inputs that determine the eigendecomposition (file identity, filter
 thresholds, sample mask, SNP restriction).  On the next run the digest is
 recomputed and compared; a mismatch forces a full recompute rather than
-silently reusing stale eigen files.
+silently reusing stale eigen files. The genotype `.bed` is fingerprinted by
+size + mtime while the `.bim` is fingerprinted by content hash, since a
+re-annotated `.bim` can change the LOCO partition without changing `.bed`.
 """
 
 from __future__ import annotations
@@ -15,11 +17,38 @@ import os
 import tempfile
 from contextlib import suppress
 from pathlib import Path
+from typing import TypedDict
 
 import numpy as np
 from loguru import logger
 
 EIGEN_CACHE_SCHEMA_VERSION: int = 1
+
+
+class EigenCacheComponents(TypedDict):
+    """Canonical, JSON-serialisable payload hashed into the cache key.
+
+    All values are plain JSON scalars: a TypedDict gives static shape
+    checking without the runtime cost or rigidity of a dataclass. JSON
+    decode yields a plain dict at runtime, so consumers that read this back
+    off disk must still guard field access defensively.
+    """
+
+    schema_version: int
+    bed_fingerprint: str
+    bim_sha256: str
+    maf_threshold: float
+    miss_threshold: float
+    valid_mask_sha256: str
+    ksnps: str
+
+
+class EigenCacheManifest(TypedDict):
+    """On-disk manifest wrapping the cache key and its hashed components."""
+
+    schema_version: int
+    cache_key: str
+    components: EigenCacheComponents
 
 
 def _sha256_file(path: Path) -> str:
@@ -38,7 +67,7 @@ def _build_components(
     miss_threshold: float,
     valid_mask: np.ndarray,
     ksnps_indices: np.ndarray | None,
-) -> dict:
+) -> EigenCacheComponents:
     """Assemble the canonical dict of cache-key components.
 
     Args:
@@ -86,7 +115,7 @@ def compute_eigen_cache_key(
     miss_threshold: float,
     valid_mask: np.ndarray,
     ksnps_indices: np.ndarray | None = None,
-) -> tuple[str, dict]:
+) -> tuple[str, EigenCacheComponents]:
     """Compute a SHA-256 cache key over all eigendecomposition determinants.
 
     Args:
@@ -147,7 +176,7 @@ def write_eigen_cache_manifest(
     prefix: str,
     key: str,
     *,
-    components: dict,
+    components: EigenCacheComponents,
 ) -> Path:
     """Write a cache manifest JSON atomically.
 
@@ -155,13 +184,13 @@ def write_eigen_cache_manifest(
         eigen_dir: Directory containing eigen files.
         prefix: Filename prefix (e.g. "result").
         key: Hex SHA-256 cache key string.
-        components: Dict of key components (the payload that was hashed) for
+        components: Key components (the payload that was hashed) for
             debuggability.
 
     Returns:
         Path to the written manifest file.
     """
-    manifest = {
+    manifest: EigenCacheManifest = {
         "schema_version": EIGEN_CACHE_SCHEMA_VERSION,
         "cache_key": key,
         "components": components,
@@ -172,6 +201,8 @@ def write_eigen_cache_manifest(
     try:
         with os.fdopen(fd, "w") as fh:
             json.dump(manifest, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
         tmp_path.replace(target)
     except Exception:
         with suppress(OSError):
@@ -180,7 +211,9 @@ def write_eigen_cache_manifest(
     return target
 
 
-def read_eigen_cache_manifest(eigen_dir: Path, prefix: str) -> dict | None:
+def read_eigen_cache_manifest(
+    eigen_dir: Path, prefix: str
+) -> EigenCacheManifest | None:
     """Read and parse the cache manifest.
 
     Args:
@@ -188,7 +221,7 @@ def read_eigen_cache_manifest(eigen_dir: Path, prefix: str) -> dict | None:
         prefix: Filename prefix.
 
     Returns:
-        Parsed manifest dict, or None if absent or corrupt.
+        Parsed manifest dict, or None if absent, corrupt, or unreadable.
     """
     path = eigen_cache_manifest_path(eigen_dir, prefix)
     try:
@@ -196,8 +229,11 @@ def read_eigen_cache_manifest(eigen_dir: Path, prefix: str) -> dict | None:
             return json.load(fh)
     except FileNotFoundError:
         return None
-    except (json.JSONDecodeError, OSError) as exc:
+    except json.JSONDecodeError as exc:
         logger.warning(f"Corrupt eigen cache manifest {path}: {exc}")
+        return None
+    except OSError as exc:
+        logger.warning(f"Could not read eigen cache manifest {path}: {exc}")
         return None
 
 
@@ -215,9 +251,22 @@ def eigen_cache_is_valid(
         Tuple of (is_valid, reason). reason is always a non-empty string.
     """
     manifest = read_eigen_cache_manifest(eigen_dir, prefix)
+    path = eigen_cache_manifest_path(eigen_dir, prefix)
     if manifest is None:
-        path = eigen_cache_manifest_path(eigen_dir, prefix)
         return False, f"no valid cache manifest found at {path}"
-    if manifest.get("cache_key") == current_key:
+    got_version = manifest.get("schema_version")
+    if got_version != EIGEN_CACHE_SCHEMA_VERSION:
+        return (
+            False,
+            f"manifest schema_version {got_version} != current "
+            f"{EIGEN_CACHE_SCHEMA_VERSION}; recomputing",
+        )
+    if "cache_key" not in manifest:
+        return (
+            False,
+            f"malformed eigen cache manifest at {path}: no cache_key "
+            f"(old-schema or truncated manifest)",
+        )
+    if manifest["cache_key"] == current_key:
         return True, "cache key matches"
     return False, "cache key mismatch: inputs changed since the eigen cache was written"

--- a/src/jamma/lmm/loco.py
+++ b/src/jamma/lmm/loco.py
@@ -42,6 +42,7 @@ from jamma.kinship import (
 from jamma.lmm.compute_numpy import compute_lmm_chunk_numpy
 from jamma.lmm.eigen import eigendecompose_kinship
 from jamma.lmm.eigen_cache import (
+    EigenCacheComponents,
     compute_eigen_cache_key,
     eigen_cache_is_valid,
     invalidate_eigen_cache_manifest,
@@ -425,7 +426,7 @@ def run_lmm_loco(
         # paths below. Those paths are mutually exclusive at runtime but key off
         # the same inputs.
         eigen_cache_key: str | None = None
-        eigen_cache_components: dict | None = None
+        eigen_cache_components: EigenCacheComponents | None = None
         if eigen_dir is not None:
             eigen_cache_key, eigen_cache_components = compute_eigen_cache_key(
                 bed_path,

--- a/tests/test_loco_eigen_cache.py
+++ b/tests/test_loco_eigen_cache.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from jamma.lmm.eigen_cache import EigenCacheComponents
 from jamma.lmm.eigen_io import read_eigen_files, write_eigen_files
 from jamma.lmm.loco import _find_loco_eigen_cache
 
@@ -29,6 +30,24 @@ MOUSE_HS1940_BFILE = MOUSE_HS1940_DIR / "mouse_hs1940"
 
 def _mouse_hs1940_exists() -> bool:
     return MOUSE_HS1940_BFILE.with_suffix(".bed").exists()
+
+
+def _dummy_components(maf_threshold: float = 0.01) -> EigenCacheComponents:
+    """Build a complete EigenCacheComponents for manifest write tests.
+
+    The manifest tests care about the cache_key, not the components payload,
+    so a valid fully-populated default keeps the call sites type-clean.
+    maf_threshold is exposed because the roundtrip test asserts on it.
+    """
+    return {
+        "schema_version": 1,
+        "bed_fingerprint": "data.bed:64:1",
+        "bim_sha256": "0" * 64,
+        "maf_threshold": maf_threshold,
+        "miss_threshold": 0.05,
+        "valid_mask_sha256": "1" * 64,
+        "ksnps": "none",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -737,7 +756,9 @@ class TestEigenCacheManifest:
             write_eigen_cache_manifest,
         )
 
-        write_eigen_cache_manifest(tmp_path, "result", "KEY123", components={})
+        write_eigen_cache_manifest(
+            tmp_path, "result", "KEY123", components=_dummy_components()
+        )
         ok, _reason = eigen_cache_is_valid(tmp_path, "result", "KEY123")
         assert ok is True
 
@@ -747,7 +768,9 @@ class TestEigenCacheManifest:
             write_eigen_cache_manifest,
         )
 
-        write_eigen_cache_manifest(tmp_path, "result", "KEY123", components={})
+        write_eigen_cache_manifest(
+            tmp_path, "result", "KEY123", components=_dummy_components()
+        )
         ok, reason = eigen_cache_is_valid(tmp_path, "result", "DIFFERENT")
         assert ok is False
         assert reason
@@ -758,14 +781,15 @@ class TestEigenCacheManifest:
             write_eigen_cache_manifest,
         )
 
+        components = _dummy_components(maf_threshold=0.01)
         path = write_eigen_cache_manifest(
-            tmp_path, "result", "KEY123", components={"maf_threshold": 0.01}
+            tmp_path, "result", "KEY123", components=components
         )
         assert path.exists()
         manifest = read_eigen_cache_manifest(tmp_path, "result")
         assert manifest is not None
         assert manifest["cache_key"] == "KEY123"
-        assert manifest["components"] == {"maf_threshold": 0.01}
+        assert manifest["components"] == components
 
     def test_corrupt_manifest_is_invalid(self, tmp_path: Path) -> None:
         from jamma.lmm.eigen_cache import (
@@ -787,7 +811,9 @@ class TestEigenCacheManifest:
             write_eigen_cache_manifest,
         )
 
-        write_eigen_cache_manifest(tmp_path, "result", "KEY", components={})
+        write_eigen_cache_manifest(
+            tmp_path, "result", "KEY", components=_dummy_components()
+        )
         manifest = eigen_cache_manifest_path(tmp_path, "result")
         assert manifest.exists()
 

--- a/tests/test_loco_eigen_cache.py
+++ b/tests/test_loco_eigen_cache.py
@@ -203,7 +203,16 @@ class TestLocoEigenCacheIntegration:
     """End-to-end tests for LOCO eigen cache write/read cycle."""
 
     def test_cached_run_produces_identical_results(self, tmp_path: Path) -> None:
-        """Write eigen, then read cache: results must be numerically identical."""
+        """Write eigen, then read cache: results must be numerically identical.
+
+        Also pins that the cache is actually reused: a regression that silently
+        recomputes instead of loading would emit no cache-found line, which the
+        log-sink assertion below catches. (loguru does not propagate to pytest's
+        caplog without wiring, so we capture via a logger sink, the project's
+        established pattern.)
+        """
+        from loguru import logger
+
         from jamma.lmm.loco import run_lmm_loco
         from jamma.validation.compare import load_gemma_assoc
         from tests.conftest import load_phenotypes_from_fam
@@ -227,17 +236,31 @@ class TestLocoEigenCacheIntegration:
             eigen_prefix="result",
         )
 
-        # Run 2: read cache (no kinship/eigendecomp)
+        # Run 2: read cache (no kinship/eigendecomp). Capture INFO so we can
+        # prove the cache was loaded rather than silently recomputed.
         out2 = tmp_path / "run2.assoc.txt"
-        run_lmm_loco(
-            bed_path=MOUSE_HS1940_BFILE,
-            phenotypes=phenotypes,
-            lmm_mode=1,
-            output_path=out2,
-            check_memory=False,
-            show_progress=False,
-            eigen_dir=eigen_dir,
-            eigen_prefix="result",
+        cache_messages: list[str] = []
+        handler_id = logger.add(
+            lambda msg: cache_messages.append(msg),
+            level="INFO",
+            format="{message}",
+        )
+        try:
+            run_lmm_loco(
+                bed_path=MOUSE_HS1940_BFILE,
+                phenotypes=phenotypes,
+                lmm_mode=1,
+                output_path=out2,
+                check_memory=False,
+                show_progress=False,
+                eigen_dir=eigen_dir,
+                eigen_prefix="result",
+            )
+        finally:
+            logger.remove(handler_id)
+
+        assert any("Found complete LOCO eigen cache" in m for m in cache_messages), (
+            f"cache was not reused (no cache-found log line): {cache_messages!r}"
         )
 
         # Compare results — both should produce non-empty output
@@ -801,6 +824,97 @@ class TestEigenCacheManifest:
         ok, reason = eigen_cache_is_valid(tmp_path, "result", "KEY")
         assert ok is False
         assert reason
+
+    def test_missing_cache_key_reports_malformed_not_input_change(
+        self, tmp_path: Path
+    ) -> None:
+        """A manifest that parses but lacks cache_key is malformed, not stale.
+
+        Mislabeling it 'inputs changed' misdirects anyone debugging an
+        unexpected invalidation, so the reason must name the malformed manifest.
+        """
+        import json
+
+        from jamma.lmm.eigen_cache import (
+            EIGEN_CACHE_SCHEMA_VERSION,
+            eigen_cache_is_valid,
+            eigen_cache_manifest_path,
+        )
+
+        path = eigen_cache_manifest_path(tmp_path, "result")
+        # Valid schema_version so the schema gate passes and we reach the
+        # missing-cache_key branch; no cache_key field.
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": EIGEN_CACHE_SCHEMA_VERSION,
+                    "components": {},
+                }
+            )
+        )
+        ok, reason = eigen_cache_is_valid(tmp_path, "result", "KEY")
+        assert ok is False
+        assert "malformed" in reason.lower()
+        assert "cache_key" in reason
+        assert "inputs changed" not in reason
+
+    def test_schema_version_mismatch_reports_schema_reason(
+        self, tmp_path: Path
+    ) -> None:
+        """A manifest with a stale schema_version is rejected explicitly.
+
+        The cache_key matches, so only the explicit schema gate (not the
+        implicit hash coupling) can produce this rejection.
+        """
+        import json
+
+        from jamma.lmm.eigen_cache import (
+            EIGEN_CACHE_SCHEMA_VERSION,
+            eigen_cache_is_valid,
+            eigen_cache_manifest_path,
+        )
+
+        path = eigen_cache_manifest_path(tmp_path, "result")
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": EIGEN_CACHE_SCHEMA_VERSION + 1,
+                    "cache_key": "KEY",
+                    "components": {},
+                }
+            )
+        )
+        ok, reason = eigen_cache_is_valid(tmp_path, "result", "KEY")
+        assert ok is False
+        assert "schema_version" in reason
+
+    def test_write_failure_leaves_no_temp_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A serialisation failure mid-write must leave no half-written artifact.
+
+        json.dump is an I/O boundary, safe to patch; the guarantee under test is
+        that the temp file is cleaned up and no manifest is left behind.
+        """
+        import json as json_mod
+
+        from jamma.lmm.eigen_cache import (
+            eigen_cache_manifest_path,
+            write_eigen_cache_manifest,
+        )
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("simulated serialisation failure")
+
+        monkeypatch.setattr(json_mod, "dump", boom)
+
+        with pytest.raises(RuntimeError, match="simulated serialisation failure"):
+            write_eigen_cache_manifest(
+                tmp_path, "result", "KEY", components=_dummy_components()
+            )
+
+        assert list(tmp_path.glob("*.json")) == []
+        assert not eigen_cache_manifest_path(tmp_path, "result").exists()
 
     def test_invalidate_removes_present_manifest_and_no_ops_when_absent(
         self, tmp_path: Path


### PR DESCRIPTION
Follow-ups from the multi-agent review of last week's changes. No Critical issues were found; these are the four Important findings plus two cheap suggestions and a type-contract tightening. No change to the cache key derivation or the validate/recompute (fail-closed) behavior.

## Changes (`eigen_cache.py` unless noted)
- **Accurate invalidation diagnostics**: a manifest that parses but lacks `cache_key` no longer reports `"inputs changed"` (which misdirects debugging) — it names the malformed/old-schema manifest. New explicit branch in `eigen_cache_is_valid`.
- **Explicit `schema_version` gate**: `eigen_cache_is_valid` now rejects a manifest whose `schema_version` differs from the current constant, with a clear reason. Previously version-safety worked *only* because the version was baked into the hashed components — implicit and fragile (a refactor moving it out would silently delete the guard). Check order: manifest-None → schema mismatch → missing key → key compare.
- **Durability**: `write_eigen_cache_manifest` now `flush()` + `os.fsync()` before the atomic `replace`, so a crash between rename and flush can't leave a parseable-but-garbage manifest.
- **Clearer logs**: `read_eigen_cache_manifest` distinguishes `JSONDecodeError` ("corrupt") from `OSError` ("could not read") — a disk/permission error isn't corruption. Both still fail-closed to recompute.
- **Typed contract**: `EigenCacheComponents` / `EigenCacheManifest` `TypedDict`s replace bare `dict` on `_build_components`, `compute_eigen_cache_key` (`tuple[str, EigenCacheComponents]`), `write_eigen_cache_manifest`, and `read_eigen_cache_manifest`. Runtime `.get`/membership guards retained (a TypedDict proves nothing at runtime). `loco.py` annotation updated to match.
- **Docs**: corrected the inaccurate "recomputed once" claim (a manifest-less cache on a pure read run recomputes *every* run until regenerated with `-eigen`) in `docs/CONFIGURATION.md` and the 5.4.0 CHANGELOG line; added `schema_version` to the listed determinants; `[Unreleased]` entry added.

## Tests (`tests/test_loco_eigen_cache.py`)
- Manifest write-failure leaves no temp file (patches `json.dump`, asserts propagation + no leftover `*.json`).
- Missing-`cache_key` manifest reports malformed, not "inputs changed".
- `schema_version` mismatch reports the schema reason (confirms the explicit gate, not just the implicit hash coupling).
- Strengthened the slow round-trip test to assert the cache was actually *reused* (log-sink check), not silently recomputed.

## Deferred (separate consideration)
- `EigenCacheContext` value object to collapse the three correlated `eigen_dir`/`key`/`components` optionals in `run_lmm_loco`.

## Verification
- ruff check / format: clean
- pyrefly `--baseline`: 0 errors (no new findings, no new suppressions; `# type: ignore` avoided)
- `pytest tests/test_loco_eigen_cache.py -m "slow or not slow"`: 38 passed, 0 skipped