### PR TITLE
chore: release 5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.1] - 2026-06-10
+
 ### Changed
 
 - **LOCO eigen-cache invalidation diagnostics**: `eigen_cache_is_valid` now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jamma"
-version = "5.4.0"
+version = "5.4.1"
 description = "Highly-Accelerated Multi-method Mixed-Model Association for large-scale GWAS"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "jamma"
-version = "5.4.0"
+version = "5.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "bed-reader" },


### PR DESCRIPTION
Release 5.4.1 — patch: eigen-cache review follow-ups (no API change).

## CHANGELOG `[5.4.1]`
- **Changed** — LOCO eigen-cache invalidation diagnostics: `eigen_cache_is_valid` distinguishes a malformed manifest (parses but no `cache_key`) from a real input change; enforces `schema_version` explicitly before the key compare (a bump now invalidates prior caches with a clear reason); `fsync`s the manifest before its atomic rename; logs corrupt-vs-unreadable distinctly; manifest/components typed via `TypedDict`. Plus corrected the "recomputed once" doc claim and 4 new/strengthened tests (#52).

Version bumped in `pyproject.toml` + `uv.lock`. Tagging `v5.4.1` after merge triggers `build-wheels.yml` → PyPI.